### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -1,5 +1,8 @@
 name: Lint and Format
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master, main]


### PR DESCRIPTION
Potential fix for [https://github.com/kiakiraki/blog/security/code-scanning/1](https://github.com/kiakiraki/blog/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only performs read operations (e.g., checking out code and running commands), the `permissions` block should limit the `GITHUB_TOKEN` to `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
