### PR TITLE
Optimize for Tailwind 4 best practices

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -48,9 +48,7 @@ const nextPost = currentIndex > 0 ? allPosts[currentIndex - 1] : null;
       <div class="max-w-4xl mx-auto">
         <!-- Article Header -->
         <header class="mb-8 text-center">
-          <h1
-            class="text-3xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6 text-balance"
-          >
+          <h1 class="text-3xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6 text-pretty">
             {title}
           </h1>
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -80,19 +80,3 @@ const posts = (await getCollection('blog')).sort(
     </div>
   </div>
 </Layout>
-
-<style>
-  .line-clamp-2 {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
-  .line-clamp-3 {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,11 +18,11 @@ const posts = (await getCollection('blog'))
   >
     <div class="container mx-auto px-4">
       <div class="max-w-4xl mx-auto text-center">
-        <h1 class="text-4xl md:text-6xl font-bold text-gray-900 dark:text-white mb-6 text-balance">
+        <h1 class="text-4xl md:text-6xl font-bold text-gray-900 dark:text-white mb-6 text-pretty">
           {SITE_TITLE}
         </h1>
         <p
-          class="text-lg md:text-xl text-gray-600 dark:text-gray-200 mb-8 max-w-2xl mx-auto text-balance"
+          class="text-lg md:text-xl text-gray-600 dark:text-gray-200 mb-8 max-w-2xl mx-auto text-pretty"
         >
           {SITE_DESCRIPTION}
         </p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -107,16 +107,6 @@
 }
 
 @layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
-
-  .line-clamp-2 {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
 }
 
 :root {


### PR DESCRIPTION
## Summary
- Replace `text-balance` with `text-pretty` for better Tailwind 4 compatibility
- Remove custom utility classes that are now included in Tailwind 4 standard
- Remove custom line-clamp styles in favor of Tailwind 4 built-in utilities

## Test plan
- [x] Build passes successfully
- [x] Lint check passes (with existing warnings unrelated to changes)
- [x] Format check passes
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.ai/code)