### PR TITLE
Add robots.txt with OGP image access permissions

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,13 @@
+User-agent: *
+Allow: /
+
+# Allow crawling of OG images
+Allow: /og/
+Allow: *.jpg
+Allow: *.jpeg
+Allow: *.png
+Allow: *.webp
+Allow: *.svg
+
+# Sitemap location
+Sitemap: https://blog.kiakiraki.dev/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Add robots.txt file to allow search engine crawling of OGP images
- Explicitly permit access to `/og/` path and common image formats
- Include sitemap location for better SEO discovery

## Test plan
- [ ] Verify robots.txt is accessible at `/robots.txt`
- [ ] Confirm OGP images are crawlable by search engines
- [ ] Test sitemap reference is valid

🤖 Generated with [Claude Code](https://claude.ai/code)