### PR TITLE
fix: change OGP image format from SVG to PNG for better social media compatibility

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,26 +1,3 @@
-# Cloudflare Pages Headers Configuration
-
-# OGP images - ensure proper caching for social media crawlers
-/og/*
+# OGP images - override Cloudflare default caching
+/og/*.png
   Cache-Control: public, max-age=31536000, immutable
-  X-Content-Type-Options: nosniff
-
-# Static assets
-/_astro/*
-  Cache-Control: public, max-age=31536000, immutable
-
-# HTML pages
-/*.html
-  Cache-Control: public, max-age=0, must-revalidate
-  X-Content-Type-Options: nosniff
-  X-Frame-Options: DENY
-  X-XSS-Protection: 1; mode=block
-  Referrer-Policy: strict-origin-when-cross-origin
-
-# Root and other pages
-/*
-  Cache-Control: public, max-age=0, must-revalidate
-  X-Content-Type-Options: nosniff
-  X-Frame-Options: DENY
-  X-XSS-Protection: 1; mode=block
-  Referrer-Policy: strict-origin-when-cross-origin

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,26 @@
+# Cloudflare Pages Headers Configuration
+
+# OGP images - ensure proper caching for social media crawlers
+/og/*
+  Cache-Control: public, max-age=31536000, immutable
+  X-Content-Type-Options: nosniff
+
+# Static assets
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# HTML pages
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  Referrer-Policy: strict-origin-when-cross-origin
+
+# Root and other pages
+/*
+  Cache-Control: public, max-age=0, must-revalidate
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -38,8 +38,8 @@ if (image && typeof image === 'string') {
         : 'image/jpeg';
 } else if (ogSlug) {
   // 動的生成画像を使用
-  ogImageUrl = new URL(`/og/${ogSlug}.svg`, Astro.site).toString();
-  ogImageType = 'image/svg+xml';
+  ogImageUrl = new URL(`/og/${ogSlug}.png`, Astro.site).toString();
+  ogImageType = 'image/png';
 } else {
   // フォールバック画像
   ogImageUrl = new URL(FallbackImage.src, Astro.url).toString();

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -76,21 +76,25 @@ if (image && typeof image === 'string') {
 
 <!-- Open Graph / Facebook -->
 <meta content="website" property="og:type" />
-<meta content={Astro.url} property="og:url" />
+<meta content={canonicalURL} property="og:url" />
 <meta content={pageTitle} property="og:title" />
 <meta content={description} property="og:description" />
 <meta content={ogImageUrl} property="og:image" />
+<meta content={ogImageUrl} property="og:image:secure_url" />
 <meta content="1200" property="og:image:width" />
 <meta content="630" property="og:image:height" />
 <meta content={ogImageType} property="og:image:type" />
+<meta content={pageTitle} property="og:image:alt" />
 <meta content="ja_JP" property="og:locale" />
+<meta content={SITE_TITLE} property="og:site_name" />
 
 <!-- Twitter -->
 <meta content="summary_large_image" property="twitter:card" />
-<meta content={Astro.url} property="twitter:url" />
+<meta content={canonicalURL} property="twitter:url" />
 <meta content={pageTitle} property="twitter:title" />
 <meta content={description} property="twitter:description" />
 <meta content={ogImageUrl} property="twitter:image" />
+<meta content={pageTitle} property="twitter:image:alt" />
 
 <!-- Theme -->
 <meta content="#0ea5e9" media="(prefers-color-scheme: light)" name="theme-color" />

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -69,8 +69,12 @@ export async function GET({ params, props }: { params: { slug: string }; props: 
       <text x="${150 + Math.max(type.length * 16 + 32, 80) / 2}" y="175" font-family="'Hiragino Sans', 'Yu Gothic', Arial, sans-serif" font-size="18" font-weight="600" fill="white" text-anchor="middle">${type}</text>
       
       <!-- Category badge (if exists) -->
-      ${category ? `<rect x="${1050 - Math.max(category.length * 16 + 32, 80)}" y="150" width="${Math.max(category.length * 16 + 32, 80)}" height="40" rx="20" fill="#f3f4f6" stroke="#e5e7eb"/>
-      <text x="${1050 - Math.max(category.length * 16 + 32, 80) / 2}" y="175" font-family="'Hiragino Sans', 'Yu Gothic', Arial, sans-serif" font-size="16" font-weight="500" fill="#374151" text-anchor="middle">${category}</text>` : ''}
+      ${
+        category
+          ? `<rect x="${1050 - Math.max(category.length * 16 + 32, 80)}" y="150" width="${Math.max(category.length * 16 + 32, 80)}" height="40" rx="20" fill="#f3f4f6" stroke="#e5e7eb"/>
+      <text x="${1050 - Math.max(category.length * 16 + 32, 80) / 2}" y="175" font-family="'Hiragino Sans', 'Yu Gothic', Arial, sans-serif" font-size="16" font-weight="500" fill="#374151" text-anchor="middle">${category}</text>`
+          : ''
+      }
       
       <!-- Title -->
       <text x="600" y="${title.length > 30 ? '280' : '300'}" font-family="'Hiragino Sans', 'Yu Gothic', Arial, sans-serif" font-size="${title.length > 30 ? '42' : '56'}" font-weight="800" fill="#1f2937" text-anchor="middle">${title.length > 50 ? title.substring(0, 50) + '...' : title}</text>
@@ -85,9 +89,7 @@ export async function GET({ params, props }: { params: { slug: string }; props: 
 
   // SVGをPNGに変換
   const sharp = (await import('sharp')).default;
-  const buffer = await sharp(Buffer.from(svg))
-    .png()
-    .toBuffer();
+  const buffer = await sharp(Buffer.from(svg)).png().toBuffer();
 
   return new Response(buffer, {
     headers: {

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -94,7 +94,6 @@ export async function GET({ params, props }: { params: { slug: string }; props: 
   return new Response(buffer, {
     headers: {
       'Content-Type': 'image/png',
-      'Cache-Control': 'public, max-age=31536000, immutable',
     },
   });
 }


### PR DESCRIPTION
## Summary

- Fixed OGP image display issues on Slack, Twitter, and other social media platforms
- Changed OG image generation from SVG to PNG format (1200x630px)
- Updated metadata tags to reference PNG URLs instead of SVG

## Changes Made

- **Replaced** `src/pages/og/[...slug].svg.ts` with `src/pages/og/[...slug].png.ts`
- **Updated** `src/components/BaseHead.astro` to use PNG format and correct MIME types
- **Implemented** SVG-to-PNG conversion using Sharp library for consistent image output
- **Maintained** existing design and dynamic content generation

## Technical Details

- Uses Sharp library for SVG-to-PNG conversion
- Maintains 1200x630 dimensions as per social media standards
- Preserves existing badge, title, description, and branding elements
- Sets proper `Content-Type: image/png` and cache headers

## Test Plan

- [x] Build process completes successfully
- [x] TypeScript checks pass
- [x] OG images generate correctly for all blog posts
- [ ] Test social media sharing on Twitter
- [ ] Test social media sharing on Slack
- [ ] Verify OGP meta tags in browser dev tools

## Problem Solved

Before: SVG OGP images were not displaying correctly on social media platforms
After: PNG format ensures consistent display across all social media platforms

🤖 Generated with [Claude Code](https://claude.ai/code)