### PR TITLE
Fix related posts time scoring

### DIFF
--- a/src/utils/relatedPosts.ts
+++ b/src/utils/relatedPosts.ts
@@ -55,7 +55,8 @@ function calculateRelatedScore(currentPost: BlogPost, targetPost: BlogPost): num
     Math.abs(currentPost.data.pubDate.getTime() - targetPost.data.pubDate.getTime()) /
     (1000 * 60 * 60 * 24); // 日数差
 
-  const timeScore = Math.max(0, 30 - daysDiff / 30); // 30日で0点
+  // 0日差で30点、30日差で0点になるようにスケール
+  const timeScore = Math.max(0, 30 - daysDiff); // 30日で0点
   score += timeScore;
 
   // タイトル類似度（最大20点） - 簡易版：共通文字数


### PR DESCRIPTION
## Summary
- Correct time-based scoring for related posts so that articles older than 30 days score zero

## Testing
- `npm run lint:check`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68955d6bcfd0832abc8ac24e10eccd30