### PR TITLE
Add unit tests for related posts scoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:check": "eslint . --ext .js,.ts,.astro",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "astro check"
+    "typecheck": "astro check",
+    "test": "vitest"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.2",
@@ -37,6 +38,7 @@
     "prettier": "^3.6.2",
     "prettier-plugin-astro": "^0.14.1",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.38.0"
+    "typescript-eslint": "^8.38.0",
+    "vitest": "^1.6.1"
   }
 }

--- a/src/utils/relatedPosts.test.ts
+++ b/src/utils/relatedPosts.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { getRelatedPosts } from './relatedPosts';
+
+type TestPost = any;
+
+const createPost = (
+  id: string,
+  title: string,
+  category: string,
+  date: string,
+): TestPost => ({
+  id,
+  data: {
+    title,
+    category,
+    pubDate: new Date(date),
+  },
+});
+
+describe('getRelatedPosts', () => {
+  it('prioritizes posts from the same category', () => {
+    const current = createPost('current', 'Current', '技術', '2025-01-01');
+    const sameCat = createPost('same', 'Same Cat', '技術', '2025-01-02');
+    const diffCat = createPost('diff', 'Diff Cat', '旅行', '2025-01-02');
+
+    const result = getRelatedPosts(current, [sameCat, diffCat]);
+    expect(result[0].id).toBe('same');
+  });
+
+  it('penalizes older publication dates', () => {
+    const current = createPost('current', 'Current', '技術', '2025-01-01');
+    const recent = createPost('recent', 'Recent', '技術', '2025-01-02');
+    const old = createPost('old', 'Old', '技術', '2024-01-02');
+
+    const result = getRelatedPosts(current, [recent, old]);
+    expect(result[0].id).toBe('recent');
+  });
+
+  it('accounts for title similarity', () => {
+    const current = createPost('current', 'Hello World', '技術', '2025-01-01');
+    const similar = createPost('similar', 'Hello World!', '技術', '2025-01-02');
+    const different = createPost('different', 'Another Topic', '技術', '2025-01-02');
+
+    const result = getRelatedPosts(current, [similar, different]);
+    expect(result[0].id).toBe('similar');
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest unit tests verifying related post scoring by category, date, and title similarity
- expose `npm test` script and Vitest dependency

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint:check`
- `npm run typecheck` *(fails: Cannot find module 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_68955ec2eed8832a83b89d4fcb93a355