### PR TITLE
Use AUTHOR_NAME for RSS and meta author

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,5 +1,5 @@
 ---
-import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import { SITE_TITLE, SITE_DESCRIPTION, AUTHOR_NAME } from '../consts';
 import FallbackImage from '../assets/blog-placeholder-1.jpg';
 import type { ImageMetadata } from 'astro';
 
@@ -71,7 +71,7 @@ if (image && typeof image === 'string') {
 <title>{pageTitle}</title>
 <meta content={pageTitle} name="title" />
 <meta content={description} name="description" />
-<meta content={SITE_TITLE} name="author" />
+<meta content={AUTHOR_NAME} name="author" />
 <meta content="index, follow" name="robots" />
 
 <!-- Open Graph / Facebook -->

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,6 +1,6 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
-import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import { SITE_TITLE, SITE_DESCRIPTION, AUTHOR_NAME } from '../consts';
 
 export async function GET(context) {
   const posts = await getCollection('blog');
@@ -20,7 +20,7 @@ export async function GET(context) {
       link: `/blog/${post.slug}/`,
       guid: `/blog/${post.slug}/`,
       categories: post.data.tags || [],
-      author: SITE_TITLE,
+      author: AUTHOR_NAME,
     })),
     customData: `
 			<language>ja</language>


### PR DESCRIPTION
## Summary
- import and use `AUTHOR_NAME` constant in RSS feed generation
- expose `AUTHOR_NAME` in base head `<meta name="author">`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:check`
- `npm run typecheck`
- `npm run build`
- `curl -s http://localhost:4321/rss.xml | head -n 20`
- `curl -s http://localhost:4321/ | grep -n 'name="author"' -n`


------
https://chatgpt.com/codex/tasks/task_e_68955ec824e4832a9217ed946f06f563