### PR TITLE
fix: refine ogp tags and fonts

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,5 +1,5 @@
 ---
-import { SITE_TITLE, SITE_DESCRIPTION, AUTHOR_NAME } from '../consts';
+import { SITE_TITLE, SITE_DESCRIPTION, AUTHOR_NAME, AUTHOR_TWITTER } from '../consts';
 import FallbackImage from '../assets/blog-placeholder-1.jpg';
 import type { ImageMetadata } from 'astro';
 
@@ -89,12 +89,14 @@ if (image && typeof image === 'string') {
 <meta content={SITE_TITLE} property="og:site_name" />
 
 <!-- Twitter -->
-<meta content="summary_large_image" property="twitter:card" />
-<meta content={canonicalURL} property="twitter:url" />
-<meta content={pageTitle} property="twitter:title" />
-<meta content={description} property="twitter:description" />
-<meta content={ogImageUrl} property="twitter:image" />
-<meta content={pageTitle} property="twitter:image:alt" />
+<meta content="summary_large_image" name="twitter:card" />
+<meta content={canonicalURL} name="twitter:url" />
+<meta content={pageTitle} name="twitter:title" />
+<meta content={description} name="twitter:description" />
+<meta content={ogImageUrl} name="twitter:image" />
+<meta content={pageTitle} name="twitter:image:alt" />
+<meta content={AUTHOR_TWITTER} name="twitter:site" />
+<meta content={AUTHOR_TWITTER} name="twitter:creator" />
 
 <!-- Theme -->
 <meta content="#0ea5e9" media="(prefers-color-scheme: light)" name="theme-color" />
@@ -108,11 +110,12 @@ if (image && typeof image === 'string') {
 <script
   async
   crossorigin="anonymous"
+  is:inline
   src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9612045894782550"
 ></script>
 
 <!-- JSON-LD Structured Data -->
-<script type="application/ld+json">
+<script is:inline type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "WebSite",

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -1,6 +1,7 @@
+import { ImageResponse } from '@vercel/og';
 import { getCollection, type CollectionEntry } from 'astro:content';
 
-export const prerender = true;
+export const runtime = 'edge';
 
 type Props = {
   post?: CollectionEntry<'blog'>;
@@ -13,13 +14,16 @@ export async function getStaticPaths() {
     props: { post } as Props,
   }));
 
-  // 特別なページのパスも追加
   paths.push(
     { params: { slug: 'home' }, props: {} as Props },
     { params: { slug: 'about' }, props: {} as Props }
   );
 
   return paths;
+}
+
+function h(type: string, props: Record<string, any> = {}, ...children: any[]): any {
+  return { type, props: { ...props, children: children.length > 1 ? children : children[0] } };
 }
 
 export async function GET({ params, props }: { params: { slug: string }; props: Props }) {
@@ -31,69 +35,144 @@ export async function GET({ params, props }: { params: { slug: string }; props: 
   let category = '';
 
   if (props.post) {
-    // ブログ記事の場合
     title = props.post.data.title;
     description = props.post.data.description || '';
     category = props.post.data.category || '';
     type = 'ブログ記事';
   } else if (slug === 'home') {
-    // ホームページ
     title = '趣味の記録';
     description = 'あきらきの趣味について記録しているブログです';
     type = 'ホーム';
   } else if (slug === 'about') {
-    // プロフィールページ
     title = 'プロフィール | 趣味の記録';
     description = 'あきらき（kiakiraki）のプロフィール';
     type = 'プロフィール';
   }
 
-  // PNG画像を生成（シンプルなSVG + sharp変換）
-  const svg = `
-    <svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-          <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
-        </linearGradient>
-      </defs>
-      
-      <!-- Background -->
-      <rect width="1200" height="630" fill="url(#bg)"/>
-      
-      <!-- Main content box -->
-      <rect x="100" y="100" width="1000" height="430" rx="24" fill="rgba(255,255,255,0.95)" stroke="none"/>
-      
-      <!-- Type badge -->
-      <rect x="150" y="150" width="${Math.max(type.length * 16 + 32, 80)}" height="40" rx="20" fill="#0ea5e9"/>
-      <text x="${150 + Math.max(type.length * 16 + 32, 80) / 2}" y="175" font-family="'Hiragino Sans', 'Yu Gothic', Arial, sans-serif" font-size="18" font-weight="600" fill="white" text-anchor="middle">${type}</text>
-      
-      <!-- Category badge (if exists) -->
-      ${
-        category
-          ? `<rect x="${1050 - Math.max(category.length * 16 + 32, 80)}" y="150" width="${Math.max(category.length * 16 + 32, 80)}" height="40" rx="20" fill="#f3f4f6" stroke="#e5e7eb"/>
-      <text x="${1050 - Math.max(category.length * 16 + 32, 80) / 2}" y="175" font-family="'Hiragino Sans', 'Yu Gothic', Arial, sans-serif" font-size="16" font-weight="500" fill="#374151" text-anchor="middle">${category}</text>`
-          : ''
-      }
-      
-      <!-- Title -->
-      <text x="600" y="${title.length > 30 ? '280' : '300'}" font-family="'Hiragino Sans', 'Yu Gothic', Arial, sans-serif" font-size="${title.length > 30 ? '42' : '56'}" font-weight="800" fill="#1f2937" text-anchor="middle">${title.length > 50 ? title.substring(0, 50) + '...' : title}</text>
-      
-      <!-- Description -->
-      ${description ? `<text x="600" y="${title.length > 30 ? '340' : '370'}" font-family="'Hiragino Sans', 'Yu Gothic', Arial, sans-serif" font-size="24" fill="#6b7280" text-anchor="middle">${description.length > 80 ? description.substring(0, 80) + '...' : description}</text>` : ''}
-      
-      <!-- Site name -->
-      <text x="1050" y="510" font-family="'Hiragino Sans', 'Yu Gothic', Arial, sans-serif" font-size="20" font-weight="600" fill="#0ea5e9" text-anchor="end">趣味の記録</text>
-    </svg>
-  `;
+  const fontRegular = await fetch(
+    'https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-jp@latest/files/noto-sans-jp-japanese-400-normal.woff'
+  ).then(res => res.arrayBuffer());
+  const fontBold = await fetch(
+    'https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-jp@latest/files/noto-sans-jp-japanese-700-normal.woff'
+  ).then(res => res.arrayBuffer());
 
-  // SVGをPNGに変換
-  const sharp = (await import('sharp')).default;
-  const buffer = await sharp(Buffer.from(svg)).png().toBuffer();
-
-  return new Response(buffer, {
-    headers: {
-      'Content-Type': 'image/png',
+  const element = h(
+    'div',
+    {
+      style: {
+        width: '1200px',
+        height: '630px',
+        display: 'flex',
+        background: 'linear-gradient(135deg,#0ea5e9 0%,#0284c7 100%)',
+        position: 'relative',
+        fontFamily: 'Noto Sans JP',
+      },
     },
+    h(
+      'div',
+      {
+        style: {
+          position: 'absolute',
+          top: '100px',
+          left: '100px',
+          width: '1000px',
+          height: '430px',
+          background: 'rgba(255,255,255,0.95)',
+          borderRadius: '24px',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '40px',
+        },
+      },
+      h(
+        'div',
+        {
+          style: {
+            position: 'absolute',
+            top: '50px',
+            left: '50px',
+            background: '#0ea5e9',
+            borderRadius: '20px',
+            padding: '8px 16px',
+            color: '#ffffff',
+            fontSize: '18px',
+            fontWeight: 600,
+          },
+        },
+        type
+      ),
+      category
+        ? h(
+            'div',
+            {
+              style: {
+                position: 'absolute',
+                top: '50px',
+                right: '50px',
+                background: '#f3f4f6',
+                borderRadius: '20px',
+                padding: '8px 16px',
+                color: '#374151',
+                fontSize: '16px',
+                fontWeight: 500,
+              },
+            },
+            category
+          )
+        : null,
+      h(
+        'div',
+        {
+          style: {
+            marginTop: title.length > 30 ? '40px' : '20px',
+            fontSize: title.length > 30 ? '42px' : '56px',
+            fontWeight: 800,
+            color: '#1f2937',
+            textAlign: 'center',
+            whiteSpace: 'pre-wrap',
+          },
+        },
+        title.length > 50 ? title.substring(0, 50) + '…' : title
+      ),
+      description
+        ? h(
+            'div',
+            {
+              style: {
+                marginTop: '20px',
+                fontSize: '24px',
+                color: '#6b7280',
+                textAlign: 'center',
+              },
+            },
+            description.length > 80 ? description.substring(0, 80) + '…' : description
+          )
+        : null,
+      h(
+        'div',
+        {
+          style: {
+            position: 'absolute',
+            bottom: '30px',
+            right: '50px',
+            fontSize: '20px',
+            fontWeight: 600,
+            color: '#0ea5e9',
+          },
+        },
+        '趣味の記録'
+      )
+    )
+  );
+
+  return new ImageResponse(element as any, {
+    width: 1200,
+    height: 630,
+    fonts: [
+      { name: 'Noto Sans JP', data: fontRegular, weight: 400, style: 'normal' },
+      { name: 'Noto Sans JP', data: fontBold, weight: 700, style: 'normal' },
+    ],
   });
 }

--- a/src/types/react.d.ts
+++ b/src/types/react.d.ts
@@ -1,0 +1,4 @@
+declare module 'react' {
+  // Minimal React types for @vercel/og
+  export type ReactElement = any;
+}


### PR DESCRIPTION
## Summary
- fix twitter meta tags and add site/creator info
- build OG image handler with `@vercel/og` and Noto Sans JP
- mark external scripts as inline for Astro

## Testing
- `npm run format`
- `npm run lint:check`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6895622fbfd8832a9be2e7fcc26617a4