### PR TITLE
fix(ogp): self-host JP fonts to prevent CJK fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Source lives in `src/` with `components/`, `layouts/`, `pages/`, `utils/`, `styles/`, and content in `content/` (blog posts under `src/content/blog`).
+- Static assets go in `public/`; build output is `dist/`.
+- Shared constants are in `src/consts.ts` (e.g., `CATEGORIES`, `SITE_TITLE`). Type aliases live in `src/types/`.
+- Import aliases: `@/*`, `@/components/*`, `@/layouts/*` (see `tsconfig.json`).
+
+## Build, Test, and Development Commands
+- `npm run dev`: Start Astro dev server at `http://localhost:4321`.
+- `npm run build`: Production build to `./dist/` (Cloudflare adapter).
+- `npm run preview`: Serve the built site locally.
+- `npm run typecheck`: TypeScript/`astro check` type analysis.
+- `npm run lint:check` / `npm run lint`: ESLint validation (fix with `npm run lint`).
+- `npm run format:check` / `npm run format`: Prettier format checks (write with `npm run format`).
+
+## Coding Style & Naming Conventions
+- Prettier: 2 spaces, single quotes, semicolons, `printWidth` 100 (Markdown 80), `trailingComma: es5`. Astro files formatted via `prettier-plugin-astro`.
+- ESLint: TypeScript + Astro; `@typescript-eslint/no-explicit-any` is disabled.
+- Components/layouts: PascalCase (e.g., `Layout.astro`); utilities: camelCase; constants: UPPER_SNAKE_CASE.
+- Tailwind CSS v4 via Vite plugin; keep utility-first classes in markup and shared rules in `src/styles/global.css`.
+
+## Content Authoring
+- Blog entries are `.md/.mdx` under `src/content/blog`. Required frontmatter in `src/content.config.ts`:
+  ```md
+  ---
+  title: 記事タイトル
+  description: 要約
+  pubDate: 2025-07-01
+  category: 技術 # one of CATEGORIES in consts.ts
+  heroImage: ../assets/hero.png
+  updatedDate: 2025-07-08
+  ---
+  ```
+
+## Testing Guidelines
+- No unit test framework configured. Validate changes with `typecheck`, `lint:check`, `format:check`, and `npm run preview`.
+- CI (`.github/workflows/lint-and-format.yml`) runs typecheck, ESLint, and Prettier checks on PRs.
+
+## Commit & Pull Request Guidelines
+- Use Conventional Commit prefixes seen in history: `feat`, `fix`, `docs`, `style`, `chore`, `refactor` (e.g., `feat: add related posts`).
+- PRs should include: clear description, linked issues, before/after screenshots for UI, and a checklist confirming local `typecheck`, `lint`, and `format` passed. Avoid committing `dist/` or `.astro/`.
+
+## Security & Configuration Tips
+- Deployment targets Cloudflare (see `astro.config.mjs`). Do not commit secrets; prefer project/environment config in the platform. Keep external fetches (e.g., fonts for OGP images) stable and version-pinned.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,39 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- Source lives in `src/` with `components/`, `layouts/`, `pages/`, `utils/`, `styles/`, and content in `content/` (blog posts under `src/content/blog`).
+
+- Source lives in `src/` with `components/`, `layouts/`, `pages/`, `utils/`,
+  `styles/`, and content in `content/` (blog posts under `src/content/blog`).
 - Static assets go in `public/`; build output is `dist/`.
-- Shared constants are in `src/consts.ts` (e.g., `CATEGORIES`, `SITE_TITLE`). Type aliases live in `src/types/`.
+- Shared constants are in `src/consts.ts` (e.g., `CATEGORIES`, `SITE_TITLE`).
+  Type aliases live in `src/types/`.
 - Import aliases: `@/*`, `@/components/*`, `@/layouts/*` (see `tsconfig.json`).
 
 ## Build, Test, and Development Commands
+
 - `npm run dev`: Start Astro dev server at `http://localhost:4321`.
 - `npm run build`: Production build to `./dist/` (Cloudflare adapter).
 - `npm run preview`: Serve the built site locally.
 - `npm run typecheck`: TypeScript/`astro check` type analysis.
-- `npm run lint:check` / `npm run lint`: ESLint validation (fix with `npm run lint`).
-- `npm run format:check` / `npm run format`: Prettier format checks (write with `npm run format`).
+- `npm run lint:check` / `npm run lint`: ESLint validation (fix with
+  `npm run lint`).
+- `npm run format:check` / `npm run format`: Prettier format checks (write with
+  `npm run format`).
 
 ## Coding Style & Naming Conventions
-- Prettier: 2 spaces, single quotes, semicolons, `printWidth` 100 (Markdown 80), `trailingComma: es5`. Astro files formatted via `prettier-plugin-astro`.
+
+- Prettier: 2 spaces, single quotes, semicolons, `printWidth` 100 (Markdown 80),
+  `trailingComma: es5`. Astro files formatted via `prettier-plugin-astro`.
 - ESLint: TypeScript + Astro; `@typescript-eslint/no-explicit-any` is disabled.
-- Components/layouts: PascalCase (e.g., `Layout.astro`); utilities: camelCase; constants: UPPER_SNAKE_CASE.
-- Tailwind CSS v4 via Vite plugin; keep utility-first classes in markup and shared rules in `src/styles/global.css`.
+- Components/layouts: PascalCase (e.g., `Layout.astro`); utilities: camelCase;
+  constants: UPPER_SNAKE_CASE.
+- Tailwind CSS v4 via Vite plugin; keep utility-first classes in markup and
+  shared rules in `src/styles/global.css`.
 
 ## Content Authoring
-- Blog entries are `.md/.mdx` under `src/content/blog`. Required frontmatter in `src/content.config.ts`:
+
+- Blog entries are `.md/.mdx` under `src/content/blog`. Required frontmatter in
+  `src/content.config.ts`:
   ```md
   ---
   title: 記事タイトル
@@ -34,12 +46,22 @@
   ```
 
 ## Testing Guidelines
-- No unit test framework configured. Validate changes with `typecheck`, `lint:check`, `format:check`, and `npm run preview`.
-- CI (`.github/workflows/lint-and-format.yml`) runs typecheck, ESLint, and Prettier checks on PRs.
+
+- No unit test framework configured. Validate changes with `typecheck`,
+  `lint:check`, `format:check`, and `npm run preview`.
+- CI (`.github/workflows/lint-and-format.yml`) runs typecheck, ESLint, and
+  Prettier checks on PRs.
 
 ## Commit & Pull Request Guidelines
-- Use Conventional Commit prefixes seen in history: `feat`, `fix`, `docs`, `style`, `chore`, `refactor` (e.g., `feat: add related posts`).
-- PRs should include: clear description, linked issues, before/after screenshots for UI, and a checklist confirming local `typecheck`, `lint`, and `format` passed. Avoid committing `dist/` or `.astro/`.
+
+- Use Conventional Commit prefixes seen in history: `feat`, `fix`, `docs`,
+  `style`, `chore`, `refactor` (e.g., `feat: add related posts`).
+- PRs should include: clear description, linked issues, before/after screenshots
+  for UI, and a checklist confirming local `typecheck`, `lint`, and `format`
+  passed. Avoid committing `dist/` or `.astro/`.
 
 ## Security & Configuration Tips
-- Deployment targets Cloudflare (see `astro.config.mjs`). Do not commit secrets; prefer project/environment config in the platform. Keep external fetches (e.g., fonts for OGP images) stable and version-pinned.
+
+- Deployment targets Cloudflare (see `astro.config.mjs`). Do not commit secrets;
+  prefer project/environment config in the platform. Keep external fetches
+  (e.g., fonts for OGP images) stable and version-pinned.

--- a/public/fonts/README.md
+++ b/public/fonts/README.md
@@ -1,14 +1,16 @@
 Place Japanese font files here to avoid CDN fetches during OGP generation.
 
 Required files (recommended from @fontsource/noto-sans-jp):
+
 - NotoSansJP-400.woff2
 - NotoSansJP-700.woff2
 
-These filenames must match the OGP loader in `src/pages/og/[...slug].png.ts`.
-If absent, the code falls back to fetching from jsDelivr.
+These filenames must match the OGP loader in `src/pages/og/[...slug].png.ts`. If
+absent, the code falls back to fetching from jsDelivr.
 
 Example (with npm):
-1) Download the two `.woff2` files from @fontsource or Google hosted sources.
-2) Save them as `public/fonts/NotoSansJP-400.woff2` and `public/fonts/NotoSansJP-700.woff2`.
-3) Run `npm run preview` and visit `/og/home.png` to verify rendering.
 
+1. Download the two `.woff2` files from @fontsource or Google hosted sources.
+2. Save them as `public/fonts/NotoSansJP-400.woff2` and
+   `public/fonts/NotoSansJP-700.woff2`.
+3. Run `npm run preview` and visit `/og/home.png` to verify rendering.

--- a/public/fonts/README.md
+++ b/public/fonts/README.md
@@ -1,0 +1,14 @@
+Place Japanese font files here to avoid CDN fetches during OGP generation.
+
+Required files (recommended from @fontsource/noto-sans-jp):
+- NotoSansJP-400.woff2
+- NotoSansJP-700.woff2
+
+These filenames must match the OGP loader in `src/pages/og/[...slug].png.ts`.
+If absent, the code falls back to fetching from jsDelivr.
+
+Example (with npm):
+1) Download the two `.woff2` files from @fontsource or Google hosted sources.
+2) Save them as `public/fonts/NotoSansJP-400.woff2` and `public/fonts/NotoSansJP-700.woff2`.
+3) Run `npm run preview` and visit `/og/home.png` to verify rendering.
+

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -38,7 +38,7 @@ async function fetchWithFallback(url: string, fallbackUrl: string): Promise<Arra
   try {
     const res = await fetch(url);
     if (res.ok) return res.arrayBuffer();
-  } catch (_) {
+  } catch {
     // ignore and try fallback
   }
   const resFallback = await fetch(fallbackUrl);
@@ -50,14 +50,8 @@ function absoluteUrl(path: string, request: Request): string {
 }
 
 async function getFonts(request: Request) {
-  font400Promise ||= fetchWithFallback(
-    absoluteUrl(FONT_LOCAL_400, request),
-    FONT_CDN_400
-  );
-  font700Promise ||= fetchWithFallback(
-    absoluteUrl(FONT_LOCAL_700, request),
-    FONT_CDN_700
-  );
+  font400Promise ||= fetchWithFallback(absoluteUrl(FONT_LOCAL_400, request), FONT_CDN_400);
+  font700Promise ||= fetchWithFallback(absoluteUrl(FONT_LOCAL_700, request), FONT_CDN_700);
   const [font400, font700] = await Promise.all([font400Promise, font700Promise]);
   return { font400, font700 };
 }


### PR DESCRIPTION
This PR fixes OGP image rendering falling back to non-JP fonts.\n\nChanges\n- Self-host Noto Sans JP (expects /public/fonts/NotoSansJP-400.woff2 and -700.woff2) with CDN fallback if absent.\n- Cache font ArrayBuffers at module scope to avoid per-request fetch.\n- Align title fontWeight to 700 to match available weights.\n- Add public/fonts/README.md with instructions.\n- Add AGENTS.md contributor guide.\n\nHow to verify\n1. Place fonts: public/fonts/NotoSansJP-400.woff2 and -700.woff2.\n2. npm run preview\n3. Open /og/home.png and a post OGP URL. Text should render with Noto Sans JP, no CJK fallback.\n\nNotes\n- In production (Cloudflare), local fonts are preferred; CDN used only as fallback.\n