### PR TITLE
chore: enable dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## Summary
- monitor GitHub Actions for updates via Dependabot

## Testing
- `npm run format:check`
- `npm run lint:check`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b98b75be70832aab43972f32d1dcfb