### PR TITLE
feat(design): トップページのログブック再構成とカード刷新（デザイン刷新 Phase 2）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@
 │   │   ├── Footer.astro        # サイトフッター
 │   │   ├── ThemeToggle.astro   # ダーク/ライトモード切替
 │   │   ├── FormattedDate.astro # 日付フォーマット
-│   │   ├── PostCard.astro      # 記事カード（一覧系ページ共通）
+│   │   ├── PostCard.astro      # 記事カード（heroImage無し時はOGP画像をサムネイルに流用）
+│   │   ├── FeaturedPostCard.astro # トップページの最新記事フィーチャーカード
 │   │   ├── CategoryBadge.astro # カテゴリバッジ
 │   │   ├── RelatedPosts.astro  # 関連記事表示
 │   │   ├── TweetButton.astro   # X (Twitter) シェアボタン

--- a/src/components/FeaturedPostCard.astro
+++ b/src/components/FeaturedPostCard.astro
@@ -1,0 +1,78 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { Image } from 'astro:assets';
+import CategoryBadge from './CategoryBadge.astro';
+
+interface Props {
+  post: CollectionEntry<'blog'>;
+}
+
+const { post } = Astro.props;
+const iso = post.data.pubDate.toISOString().slice(0, 10);
+---
+
+<article class="post-card group h-full">
+  {
+    post.data.heroImage ? (
+      <a class="flex h-full flex-col-reverse md:flex-row" href={`/blog/${post.id}/`}>
+        <div class="flex-[1.15] p-8 flex flex-col justify-between gap-6">
+          <div>
+            <div class="flex items-center gap-3">
+              <time class="font-mono text-xs tracking-wider text-ink-muted" datetime={iso}>
+                {iso}
+              </time>
+              <CategoryBadge category={post.data.category} size="md" />
+            </div>
+            <h2 class="mt-3 text-2xl md:text-[2rem] font-bold leading-snug text-pretty group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+              {post.data.title}
+            </h2>
+            {post.data.description && (
+              <p class="mt-3 text-ink-muted max-w-[34em]">{post.data.description}</p>
+            )}
+          </div>
+          <span class="font-mono text-xs tracking-[0.14em] text-ink-muted group-hover:text-primary-600 dark:group-hover:text-primary-400 group-hover:translate-x-0.5 transition self-end">
+            READ →
+          </span>
+        </div>
+        <div class="md:flex-1 border-b md:border-b-0 md:border-l border-line overflow-hidden aspect-[40/21] md:aspect-auto">
+          <Image
+            alt={post.data.title}
+            class="w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-300"
+            decoding="async"
+            fetchpriority="high"
+            format="webp"
+            height={480}
+            loading="eager"
+            sizes="(max-width: 768px) 100vw, 45vw"
+            src={post.data.heroImage}
+            width={640}
+            widths={[640, 960]}
+          />
+        </div>
+      </a>
+    ) : (
+      <a
+        class="flex h-full flex-col justify-between gap-6 p-8 min-h-[300px]"
+        href={`/blog/${post.id}/`}
+      >
+        <div>
+          <div class="flex items-center gap-3">
+            <time class="font-mono text-xs tracking-wider text-ink-muted" datetime={iso}>
+              {iso}
+            </time>
+            <CategoryBadge category={post.data.category} size="md" />
+          </div>
+          <h2 class="mt-3 text-2xl md:text-[2rem] font-bold leading-snug text-pretty group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+            {post.data.title}
+          </h2>
+          {post.data.description && (
+            <p class="mt-3 text-ink-muted max-w-[34em]">{post.data.description}</p>
+          )}
+        </div>
+        <span class="font-mono text-xs tracking-[0.14em] text-ink-muted group-hover:text-primary-600 dark:group-hover:text-primary-400 group-hover:translate-x-0.5 transition self-end">
+          READ →
+        </span>
+      </a>
+    )
+  }
+</article>

--- a/src/components/FeaturedPostCard.astro
+++ b/src/components/FeaturedPostCard.astro
@@ -41,7 +41,6 @@ const iso = post.data.pubDate.toISOString().slice(0, 10);
             decoding="async"
             fetchpriority="high"
             format="webp"
-            height={480}
             loading="eager"
             sizes="(max-width: 768px) 100vw, 45vw"
             src={post.data.heroImage}

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -23,7 +23,6 @@ const iso = post.data.pubDate.toISOString().slice(0, 10);
             class="w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-300"
             decoding="async"
             format="webp"
-            height={210}
             loading="lazy"
             sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 384px"
             src={post.data.heroImage}

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,67 +1,67 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import { Image } from 'astro:assets';
-import FormattedDate from './FormattedDate.astro';
 import CategoryBadge from './CategoryBadge.astro';
 
 interface Props {
   post: CollectionEntry<'blog'>;
+  compact?: boolean;
 }
 
-const { post } = Astro.props;
+const { post, compact = false } = Astro.props;
+const iso = post.data.pubDate.toISOString().slice(0, 10);
 ---
 
-<article class="card group hover:shadow-xl transition-all duration-300">
-  <a class="block" href={`/blog/${post.id}/`}>
-    {
-      post.data.heroImage && (
-        <div class="mb-4 overflow-hidden rounded-lg aspect-video">
+<article class="post-card group">
+  <a class="flex h-full flex-col" href={`/blog/${post.id}/`}>
+    <div class="aspect-[40/21] overflow-hidden border-b border-line">
+      {
+        post.data.heroImage ? (
           <Image
             alt={post.data.title}
-            class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+            class="w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-300"
             decoding="async"
             format="webp"
-            height={225}
+            height={210}
             loading="lazy"
             sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 384px"
             src={post.data.heroImage}
             width={400}
             widths={[400, 600, 800]}
           />
-        </div>
-      )
-    }
+        ) : (
+          <img
+            alt=""
+            class="w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-300"
+            decoding="async"
+            height="630"
+            loading="lazy"
+            src={`/og/${post.id}.png`}
+            width="1200"
+          />
+        )
+      }
+    </div>
 
-    <div class="space-y-3">
+    <div class="p-5 flex flex-col gap-2 flex-1">
+      <div class="flex items-center gap-3">
+        <time class="font-mono text-xs tracking-wider text-ink-muted" datetime={iso}>
+          {iso}
+        </time>
+        <CategoryBadge category={post.data.category} />
+      </div>
+
       <h2
-        class="text-xl font-semibold text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors line-clamp-2"
+        class="text-base font-semibold leading-normal text-ink group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors line-clamp-2 text-pretty"
       >
         {post.data.title}
       </h2>
 
       {
-        post.data.description && (
-          <p class="text-gray-600 dark:text-gray-300 text-sm line-clamp-3">
-            {post.data.description}
-          </p>
+        !compact && post.data.description && (
+          <p class="text-sm text-ink-muted line-clamp-2">{post.data.description}</p>
         )
       }
-
-      <div class="flex items-center justify-between pt-2">
-        <div class="text-sm text-gray-500 dark:text-gray-300">
-          <FormattedDate date={post.data.pubDate} />
-        </div>
-
-        <span
-          class="text-primary-600 dark:text-primary-400 text-sm font-medium group-hover:text-primary-700 dark:group-hover:text-primary-300 transition-colors"
-        >
-          続きを読む →
-        </span>
-      </div>
-
-      <div class="mt-3">
-        <CategoryBadge category={post.data.category} />
-      </div>
     </div>
   </a>
 </article>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from 'astro:content';
 import { Image } from 'astro:assets';
 import CategoryBadge from './CategoryBadge.astro';
+import { SITE_TITLE } from '../consts';
 
 interface Props {
   post: CollectionEntry<'blog'>;
@@ -30,15 +31,10 @@ const iso = post.data.pubDate.toISOString().slice(0, 10);
             widths={[400, 600, 800]}
           />
         ) : (
-          <img
-            alt=""
-            class="w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-300"
-            decoding="async"
-            height="630"
-            loading="lazy"
-            src={`/og/${post.id}.png`}
-            width="1200"
-          />
+          <div aria-hidden="true" class="og-thumb">
+            <span class="og-thumb__title">{post.data.title}</span>
+            <span class="og-thumb__site">{SITE_TITLE}</span>
+          </div>
         )
       }
     </div>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -2,7 +2,6 @@
 import type { CollectionEntry } from 'astro:content';
 import { Image } from 'astro:assets';
 import CategoryBadge from './CategoryBadge.astro';
-import { SITE_TITLE } from '../consts';
 
 interface Props {
   post: CollectionEntry<'blog'>;
@@ -30,10 +29,15 @@ const iso = post.data.pubDate.toISOString().slice(0, 10);
             widths={[400, 600, 800]}
           />
         ) : (
-          <div aria-hidden="true" class="og-thumb">
-            <span class="og-thumb__title">{post.data.title}</span>
-            <span class="og-thumb__site">{SITE_TITLE}</span>
-          </div>
+          <img
+            alt=""
+            class="w-full h-full object-cover group-hover:scale-[1.03] transition-transform duration-300"
+            decoding="async"
+            height="630"
+            loading="lazy"
+            src={`/og/${post.id}.png`}
+            width="1200"
+          />
         )
       }
     </div>

--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -32,7 +32,6 @@ const { relatedPosts } = Astro.props;
                     alt={post.data.title}
                     class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                     format="webp"
-                    height={169}
                     loading="lazy"
                     sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 256px"
                     src={post.data.heroImage}

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -92,7 +92,6 @@ const ogImageHeight = heroImage ? heroImage.height : 630;
             decoding="async"
             fetchpriority="high"
             format="webp"
-            height={600}
             loading="eager"
             sizes="100vw"
             src={heroImage}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -64,10 +64,10 @@ const { title, description, image, ogSlug, robots } = Astro.props;
     </BaseHead>
   </head>
   <body class="min-h-full flex flex-col bg-surface text-ink">
-    <!-- Dark mode background effects (dot grid + gradient orb) -->
-    <div aria-hidden="true" class="dark-bg-effects">
-      <div class="dark-bg-effects__dots"></div>
-      <div class="dark-bg-effects__orb"></div>
+    <!-- Logbook background effects (dot grid + gradient orb) -->
+    <div aria-hidden="true" class="bg-effects">
+      <div class="bg-effects__dots"></div>
+      <div class="bg-effects__orb"></div>
     </div>
 
     <a class="skip-link" href="#main-content">メインコンテンツへスキップ</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,17 @@
 ---
 import Layout from '@/layouts/Layout.astro';
 import PostCard from '@/components/PostCard.astro';
-import { SITE_TITLE, SITE_DESCRIPTION, POSTS_PER_PAGE } from '../consts';
+import FeaturedPostCard from '@/components/FeaturedPostCard.astro';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 import { getAllPosts } from '@/utils/posts';
 import { jsonLdStringify } from '@/utils/jsonld';
 
 export const prerender = true;
 
-const posts = (await getAllPosts()).slice(0, POSTS_PER_PAGE);
+const posts = (await getAllPosts()).slice(0, 9);
+const featured = posts[0];
+const side = posts.slice(1, 3);
+const log = posts.slice(3, 9);
 
 const structuredHome = jsonLdStringify({
   '@context': 'https://schema.org',
@@ -26,51 +30,63 @@ const structuredHome = jsonLdStringify({
 
 <Layout description={SITE_DESCRIPTION} ogSlug="home" title={SITE_TITLE}>
   <script is:inline set:html={structuredHome} type="application/ld+json" />
-  <!-- Hero Section -->
-  <section
-    class="bg-gradient-to-br from-primary-50 to-primary-100 dark:from-primary-950 dark:to-primary-900 py-16 md:py-24 animate-fade-in"
-  >
-    <div class="container mx-auto px-4">
-      <div class="max-w-4xl mx-auto text-center">
-        <h1 class="text-4xl md:text-6xl font-bold text-gray-900 dark:text-white mb-6 text-pretty">
-          {SITE_TITLE}
-        </h1>
-        <p
-          class="text-lg md:text-xl text-gray-600 dark:text-gray-200 mb-8 max-w-2xl mx-auto text-pretty"
+
+  <div class="container mx-auto px-4 pb-16">
+    <div class="max-w-6xl mx-auto">
+      <!-- Intro -->
+      <div
+        class="animate-fade-in flex flex-wrap items-baseline justify-between gap-x-6 gap-y-2 pt-11 pb-7"
+      >
+        <h1 class="text-2xl md:text-3xl font-bold">{SITE_TITLE}</h1>
+        <p class="text-ink-muted text-[0.95rem]">{SITE_DESCRIPTION}</p>
+      </div>
+
+      {
+        featured && (
+          <>
+            <div class="section-label mb-4">
+              <span>Latest</span>
+            </div>
+
+            <div class="animate-fade-in-delay-1 grid gap-4 lg:grid-cols-[1.6fr_1fr]">
+              <FeaturedPostCard post={featured} />
+              {side.length > 0 && (
+                <div class="flex flex-col gap-4">
+                  {side.map(post => (
+                    <PostCard compact post={post} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        )
+      }
+
+      {
+        log.length > 0 && (
+          <>
+            <div class="section-label mt-10 mb-4">
+              <span>Log</span>
+            </div>
+
+            <div class="animate-fade-in-delay-2 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {log.map(post => (
+                <PostCard compact post={post} />
+              ))}
+            </div>
+          </>
+        )
+      }
+
+      <div class="flex justify-center mt-10">
+        <a
+          aria-label="すべての記事を見る"
+          class="font-mono text-[13px] tracking-[0.1em] text-ink-muted border border-line rounded-full px-6 py-2 hover:text-primary-600 dark:hover:text-primary-400 hover:border-line-strong transition-colors"
+          href="/blog/"
         >
-          {SITE_DESCRIPTION}
-        </p>
-        <div class="flex flex-col sm:flex-row gap-4 justify-center">
-          <a class="btn-primary" href="/blog"> ブログを読む </a>
-          <a class="btn-secondary" href="/about"> プロフィール </a>
-        </div>
+          ALL POSTS →
+        </a>
       </div>
     </div>
-  </section>
-
-  <!-- Featured Posts -->
-  <section class="py-16 md:py-20 animate-fade-in-delay-1">
-    <div class="container mx-auto px-4">
-      <div class="max-w-6xl mx-auto">
-        <div class="mb-8">
-          <div class="section-label mb-4">
-            <span>Latest Posts</span>
-          </div>
-          <div class="flex items-center justify-between">
-            <h2 class="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white">最新記事</h2>
-            <a
-              class="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium transition-colors"
-              href="/blog"
-            >
-              すべての記事を見る →
-            </a>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {posts.map(post => <PostCard post={post} />)}
-        </div>
-      </div>
-    </div>
-  </section>
+  </div>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -237,6 +237,41 @@
     background: rgb(30 41 59 / 0.6);
   }
 
+  /* PostCardのOGPフォールバックサムネイル。/og/*.png と同じ配色をCSSで
+     full-bleed描画する（画像版は白カード+枠のデザインで、サムネイル縮小時に
+     枠が余白に見えるため使わない） */
+  .og-thumb {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: 1rem 1.25rem;
+    background: linear-gradient(
+      135deg,
+      var(--color-primary),
+      color-mix(in oklab, var(--color-primary) 80%, black)
+    );
+  }
+
+  .og-thumb__title {
+    @apply line-clamp-2 text-pretty;
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 1.02rem;
+    line-height: 1.5;
+  }
+
+  .og-thumb__site {
+    @apply font-mono;
+    position: absolute;
+    right: 0.875rem;
+    bottom: 0.625rem;
+    font-size: 9px;
+    letter-spacing: 0.14em;
+    color: rgb(255 255 255 / 0.6);
+  }
+
   .link-preview {
     @apply my-6;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -237,41 +237,6 @@
     background: rgb(30 41 59 / 0.6);
   }
 
-  /* PostCardのOGPフォールバックサムネイル。/og/*.png と同じ配色をCSSで
-     full-bleed描画する（画像版は白カード+枠のデザインで、サムネイル縮小時に
-     枠が余白に見えるため使わない） */
-  .og-thumb {
-    position: relative;
-    display: flex;
-    align-items: center;
-    width: 100%;
-    height: 100%;
-    padding: 1rem 1.25rem;
-    background: linear-gradient(
-      135deg,
-      var(--color-primary),
-      color-mix(in oklab, var(--color-primary) 80%, black)
-    );
-  }
-
-  .og-thumb__title {
-    @apply line-clamp-2 text-pretty;
-    color: #ffffff;
-    font-weight: 700;
-    font-size: 1.02rem;
-    line-height: 1.5;
-  }
-
-  .og-thumb__site {
-    @apply font-mono;
-    position: absolute;
-    right: 0.875rem;
-    bottom: 0.625rem;
-    font-size: 9px;
-    letter-spacing: 0.14em;
-    color: rgb(255 255 255 / 0.6);
-  }
-
   .link-preview {
     @apply my-6;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,12 +6,14 @@
 
 :root {
   color-scheme: light;
-  --surface: #ffffff;
+  --surface: oklch(0.98 0.005 250);
   --surface-raised: #ffffff;
   --ink: #111827;
   --ink-muted: #4b5563;
   --line: #e5e7eb;
   --line-strong: #d1d5db;
+  --dots: rgb(27 33 44 / 0.035);
+  --orb: transparent;
 }
 
 .dark {
@@ -22,6 +24,8 @@
   --ink-muted: #94a3b8;
   --line: rgb(51 65 85 / 0.3);
   --line-strong: rgb(71 85 105 / 0.5);
+  --dots: rgb(255 255 255 / 0.045);
+  --orb: color-mix(in oklab, var(--color-primary) 7%, transparent);
 }
 
 @theme inline {
@@ -76,37 +80,28 @@
     @apply transition-colors duration-200;
   }
 
-  /* Portfolio-inspired background effects (dark mode only) */
-  .dark-bg-effects {
+  /* Logbook-inspired background effects (dot grid + gradient orb, both themes) */
+  .bg-effects {
     position: fixed;
     inset: 0;
     z-index: 0;
     pointer-events: none;
-    display: none;
   }
 
-  .dark .dark-bg-effects {
-    display: block;
-  }
-
-  .dark-bg-effects__dots {
+  .bg-effects__dots {
     position: absolute;
     inset: 0;
-    background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='1' cy='1' r='0.6' fill='white' fill-opacity='0.04'/%3E%3C/svg%3E");
-    background-repeat: repeat;
+    background-image: radial-gradient(var(--dots) 1px, transparent 1px);
+    background-size: 24px 24px;
   }
 
-  .dark-bg-effects__orb {
+  .bg-effects__orb {
     position: absolute;
     top: -100px;
     left: -200px;
     width: 600px;
     height: 600px;
-    background: radial-gradient(
-      circle,
-      color-mix(in oklab, var(--color-primary) 6%, transparent) 0%,
-      transparent 70%
-    );
+    background: radial-gradient(circle, var(--orb) 0%, transparent 70%);
     filter: blur(60px);
   }
 
@@ -216,6 +211,30 @@
     background: rgba(30, 41, 59, 0.8);
     border-color: var(--line-strong);
     box-shadow: none;
+  }
+
+  .post-card {
+    background: var(--surface-raised);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+    transition:
+      border-color 0.2s ease,
+      background 0.2s ease;
+  }
+
+  .post-card:hover {
+    border-color: var(--line-strong);
+  }
+
+  .dark .post-card {
+    background: rgb(15 23 42 / 0.45);
+    box-shadow: none;
+  }
+
+  .dark .post-card:hover {
+    background: rgb(30 41 59 / 0.6);
   }
 
   .link-preview {


### PR DESCRIPTION
## 概要

デザイン刷新プロジェクトのPhase 2です。「ログブック（記録帳）」コンセプトに基づき、トップページをコンテンツファーストに再構成し、記事カードを刷新します。

モックアップ（承認済み）: https://claude.ai/code/artifact/ffd46f1e-52da-47b6-b0f4-43221ea2b159

## 変更内容

### トップページ再構成（`index.astro`）
- グラデーションヒーロー + CTAボタンを廃止し、サイト名 + 一行説明の静かな導入に
- **Latest**: 最新記事のフィーチャーカード + 2・3番目のコンパクトカード
- **Log**: 4件目以降の3カラムカードグリッド（記事数が少なくても壊れないようガード付き）
- 末尾に `ALL POSTS →` ピルリンク（/blog/ へ）
- JSON-LDの `hasPart` は表示中の最大9件を反映

### PostCard刷新
- 全カードに **40:21のサムネイル枠**。heroImage無しの記事は**ビルド済みOGP画像 `/og/{id}.png` をフォールバック表示**（1200×630=40:21ちょうどなのでクロップゼロ、`loading="lazy"`）
- 等幅フォントの日付スタンプ（`<time>`）+ カテゴリバッジをタイトル上のメタ行に
- 「続きを読む →」を削除（カード全体がリンクのため冗長）
- `compact` propでdescription非表示（トップページで使用）。`/blog/` 一覧・カテゴリページは自動で新デザインに追従
- 新設の `.post-card` クラス（画像が縁までフラッシュ）。既存 `.card`（記事ページの前後ナビで使用）はそのまま

### FeaturedPostCard（新規）
- heroImage無し: タイポグラフィのみのレイアウト + `READ →`（OGP画像は使わない——縦長クロップで画像内の文字が切れるため）
- heroImage有り: テキスト左・写真右の2カラム（モバイルは写真上）

### ライトモード色調
- 背景を純白 → 寒色オフホワイト `oklch(0.98 0.005 250)` に
- ドットグリッド背景を両テーマ共通で表示（`--dots` / `--orb` トークン化、`.dark-bg-effects` → `.bg-effects` にリネーム、SVG data URIをCSS gradientに置換）

### 画像バグ修正
- `<Image>` にソースと比率の合わない `height` を渡していた4箇所（PostCard / FeaturedPostCard / RelatedPosts / BlogPostヒーロー）を修正。dev環境で画像に黒帯がパディングされる原因だった（本番は元寸パススルーのため影響なし）。クロップは各コンテナのCSS `object-cover` が一元的に担当

## 検証

- [x] `npm run lint:check` — 0件
- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 33/33 pass
- [x] `npm run build` — 成功。`dist/client/index.html` でカード8枚（全記事）、hero無し3記事へのOGPフォールバック、旧ヒーロー（`bg-gradient-to-br`）の消滅を確認
- [x] devサーバーの配信画像を直接取得し、黒帯なし・縦横比保持を画像レベルで確認
- [x] ユーザーによるdev環境での目視確認済み

## 補足

- 途中でOGPフォールバックをCSS描画に切り替えたコミットがありますが、ユーザー判断で当初のOGP画像方式に戻しています（revertコミット含む）
- 本番の `imageService: 'compile'` が `widths` 指定のsrcset候補を実際には縮小せず元寸で出力している件は、本PRとは別の改善候補として認識済み

## 今後のフェーズ（別PR予定）

3. 記事ページの読書体験（行長・TOC幅・ヘッダー左寄せ）
4. View Transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)