### PR TITLE
feat(design): 記事ページの読書体験改善（デザイン刷新 Phase 3）

### DIFF
--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,9 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
-import { Image } from 'astro:assets';
-import FormattedDate from './FormattedDate.astro';
-import Icon from './Icon.astro';
-import CategoryBadge from './CategoryBadge.astro';
+import PostCard from './PostCard.astro';
 
 interface Props {
   relatedPosts: CollectionEntry<'blog'>[];
@@ -16,57 +13,16 @@ const { relatedPosts } = Astro.props;
   relatedPosts.length > 0 && (
     <section class="mt-12 pt-8 border-t border-line">
       <div class="mb-6">
-        <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">関連記事</h2>
-        <p class="text-gray-600 dark:text-gray-300 text-sm">
-          この記事に関連する記事をピックアップしました
-        </p>
+        <div class="section-label mb-4">
+          <span>Related</span>
+        </div>
+        <h2 class="text-xl font-bold mb-2">関連記事</h2>
+        <p class="text-ink-muted text-sm">この記事に関連する記事をピックアップしました</p>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {relatedPosts.map(post => (
-          <article class="group card hover:shadow-lg transition-all duration-300">
-            <a class="block" href={`/blog/${post.id}/`}>
-              {post.data.heroImage && (
-                <div class="mb-4 overflow-hidden rounded-lg aspect-video">
-                  <Image
-                    alt={post.data.title}
-                    class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                    format="webp"
-                    loading="lazy"
-                    sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 256px"
-                    src={post.data.heroImage}
-                    width={300}
-                    widths={[320, 480, 640, 800]}
-                  />
-                </div>
-              )}
-
-              <div class="space-y-3">
-                <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-                  <CategoryBadge category={post.data.category} />
-                  <FormattedDate date={post.data.pubDate} />
-                </div>
-
-                <h3 class="font-semibold text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors line-clamp-2">
-                  {post.data.title}
-                </h3>
-
-                {post.data.description && (
-                  <p class="text-gray-600 dark:text-gray-300 text-sm line-clamp-2">
-                    {post.data.description}
-                  </p>
-                )}
-
-                <div class="flex items-center text-primary-600 dark:text-primary-400 text-sm font-medium group-hover:text-primary-700 dark:group-hover:text-primary-300 transition-colors">
-                  続きを読む
-                  <Icon
-                    class="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform"
-                    name="chevron-right"
-                  />
-                </div>
-              </div>
-            </a>
-          </article>
+          <PostCard compact post={post} />
         ))}
       </div>
     </section>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -24,6 +24,8 @@ interface Props {
 const { post, headings } = Astro.props;
 const { title, description, pubDate, updatedDate, heroImage, category } = post.data;
 const slug = post.id;
+const pubIso = pubDate.toISOString().slice(0, 10);
+const updatedIso = updatedDate ? updatedDate.toISOString().slice(0, 10) : null;
 
 // 記事のURLを取得
 const articleUrl = Astro.url.href;
@@ -106,60 +108,49 @@ const ogImageHeight = heroImage ? heroImage.height : 630;
       <div class="max-w-6xl mx-auto">
         <div class="lg:grid lg:grid-cols-12 lg:gap-8">
           <!-- Main Content -->
-          <div class="lg:col-span-8">
-            <!-- Article Header -->
-            <header class="mb-8 text-center animate-fade-in">
-              <h1
-                class="text-3xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6 text-pretty"
-              >
-                {title}
-              </h1>
-
-              <div
-                class="flex flex-col sm:flex-row items-center justify-center gap-4 text-sm text-gray-600 dark:text-gray-300"
-              >
-                <div class="flex items-center gap-2">
-                  <Icon class="w-4 h-4" name="calendar" />
-                  <span>公開日: <FormattedDate date={pubDate} /></span>
+          <div class="lg:col-span-9">
+            <div class="max-w-[42rem]">
+              <!-- Article Header -->
+              <header class="mb-8 animate-fade-in">
+                <div class="section-label mb-4">
+                  <span>Article</span>
                 </div>
 
-                {
-                  updatedDate && (
-                    <div class="flex items-center gap-2">
-                      <Icon class="w-4 h-4" name="refresh" />
-                      <span>
-                        更新日: <FormattedDate date={updatedDate} />
+                <div class="flex flex-wrap items-center gap-3">
+                  <time class="font-mono text-sm tracking-wider text-ink-muted" datetime={pubIso}>
+                    {pubIso}
+                  </time>
+
+                  {
+                    updatedDate && updatedIso && (
+                      <span class="font-mono text-sm tracking-wider text-ink-muted">
+                        (更新: <time datetime={updatedIso}>{updatedIso}</time>)
                       </span>
-                    </div>
-                  )
-                }
+                    )
+                  }
+
+                  <a
+                    class="category-chip inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm font-medium transition-all hover:opacity-80"
+                    data-category={category}
+                    href={`/category/${category}/`}
+                  >
+                    <Icon class="w-4 h-4" name="tag" />
+                    {category}
+                  </a>
+                </div>
+
+                <h1 class="mt-4 text-3xl md:text-4xl font-bold text-pretty">{title}</h1>
+              </header>
+
+              <!-- Mobile TOC -->
+              <div class="lg:hidden">
+                {headings && headings.length > 0 && <TableOfContents headings={headings} />}
               </div>
 
-              <!-- Category Badge -->
-              <div class="mt-4">
-                <a
-                  class="category-chip inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm font-medium transition-all hover:opacity-80"
-                  data-category={category}
-                  href={`/category/${category}/`}
-                >
-                  <Icon class="w-4 h-4" name="tag" />
-                  {category}
-                </a>
+              <!-- Article Content -->
+              <div class="prose prose-lg dark:prose-invert max-w-[42rem]">
+                <slot />
               </div>
-
-              <div class="section-label justify-center mt-6 max-w-xs mx-auto">
-                <span>Article</span>
-              </div>
-            </header>
-
-            <!-- Mobile TOC -->
-            <div class="lg:hidden">
-              {headings && headings.length > 0 && <TableOfContents headings={headings} />}
-            </div>
-
-            <!-- Article Content -->
-            <div class="prose prose-lg dark:prose-invert max-w-none">
-              <slot />
             </div>
 
             <!-- ここにTweetButtonを配置 -->
@@ -180,7 +171,7 @@ const ogImageHeight = heroImage ? heroImage.height : 630;
                         <p class="text-sm text-gray-500 dark:text-gray-300 mb-2">前の記事</p>
                         <a
                           aria-label={prevPost.data.title}
-                          class="group block card hover:shadow-lg transition-all duration-200"
+                          class="group block post-card p-5 transition-all duration-200"
                           href={`/blog/${prevPost.id}/`}
                         >
                           <div class="flex items-center gap-3">
@@ -206,7 +197,7 @@ const ogImageHeight = heroImage ? heroImage.height : 630;
                         <p class="text-sm text-gray-500 dark:text-gray-300 mb-2">次の記事</p>
                         <a
                           aria-label={nextPost.data.title}
-                          class="group block card hover:shadow-lg transition-all duration-200"
+                          class="group block post-card p-5 transition-all duration-200"
                           href={`/blog/${nextPost.id}/`}
                         >
                           <div class="flex items-center gap-3">
@@ -247,7 +238,7 @@ const ogImageHeight = heroImage ? heroImage.height : 630;
           </div>
 
           <!-- Table of Contents Sidebar -->
-          <aside class="hidden lg:block lg:col-span-4">
+          <aside class="hidden lg:block lg:col-span-3">
             <div class="lg:sticky lg:top-8">
               {headings && headings.length > 0 && <TableOfContents headings={headings} />}
             </div>


### PR DESCRIPTION
## 概要

デザイン刷新プロジェクトのPhase 3です。記事ページの読書体験を「ログブック」コンセプトに揃えます。

## 変更内容

### 本文の行長制限
- `prose` の `max-w-none` をやめ **`max-w-[42rem]`**（日本語で1行40字前後）に。大画面で1行が長くなりすぎる問題を解消
- 記事ヘッダー・モバイルTOC・本文を共通の42remラッパーで整列。TweetButton・関連記事・前後ナビはカラム全幅のまま

### カラム比の変更
- 本文:TOCサイドバーを `8:4` → **`9:3`** に（TOCがページの1/3を占めていた）

### 記事ヘッダーのログブック化
- 中央寄せ → 左寄せ。`Article` のsection-label（罫線付き）→ 等幅日付スタンプ `2025-08-30`（更新日があれば `(更新: …)` を併記）+ カテゴリチップ → タイトルの順
- カレンダー/リフレッシュアイコンの日付行を廃止、タイトルは `md:text-5xl` → `md:text-4xl` に一段落ち着かせた

### 関連記事の共通化
- `RelatedPosts` の独自カードマークアップ（約50行）を削除し、共通の `<PostCard compact>` を再利用。heroImage無しの関連記事にもOGP画像サムネイルが付き、トップページ・一覧と完全に同じ見た目に

### 前後記事ナビ
- `.card` → `.post-card p-5`（Phase 2のカードスタイルに統一）

## 検証

- [x] `npm run lint:check` / `npm run typecheck` / `npm test`（33件） / `npm run build` すべてパス
- [x] ビルド出力の記事HTMLで 9:3カラム・`max-w-[42rem]`×2・関連記事+前後ナビの `post-card` 5枚を確認
- [x] `updatedDate` 付き記事は現存しないため更新日表記は条件分岐のコードのみ（ロジックは既存踏襲）

## 残フェーズ

4. View Transitions（カード→記事のヒーロー画像モーフ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)