### PR TITLE
feat(design): View Transitions導入とヒーロー画像モーフ（デザイン刷新 Phase 4）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,10 @@ export const CATEGORIES = [
       `/blog/page/[page]/`（2ページ目以降）
 - [x] **MDXエディタ（dev専用）** - `npm run dev:editor` で `/editor`
       から記事作成・画像アップロード
+- [x] **View Transitions** -
+      ClientRouterによるクライアントサイド遷移。カードのヒーロー画像が記事ヒーローへモーフ（`transition:name="hero-{id}"`）。動的スクリプトは
+      `astro:page-load` + AbortControllerで冪等化、テーマは `astro:after-swap`
+      で再適用
 
 ## 実装待ちの改善リスト
 

--- a/src/components/FeaturedPostCard.astro
+++ b/src/components/FeaturedPostCard.astro
@@ -44,6 +44,7 @@ const iso = post.data.pubDate.toISOString().slice(0, 10);
             loading="eager"
             sizes="(max-width: 768px) 100vw, 45vw"
             src={post.data.heroImage}
+            transition:name={`hero-${post.id.replaceAll('/', '-')}`}
             width={640}
             widths={[640, 960]}
           />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -140,7 +140,15 @@ import { SITE_TITLE, CATEGORIES, GITHUB_URL } from '../consts';
 </header>
 
 <script>
+  let headerAbortController: AbortController | undefined;
+
   function initHeader() {
+    // astro:page-load はページ遷移のたびに発火するため、前回登録した
+    // document/windowレベルのリスナーを破棄してから再登録する（冪等化）
+    headerAbortController?.abort();
+    headerAbortController = new AbortController();
+    const { signal } = headerAbortController;
+
     const mobileMenuButton = document.getElementById('mobile-menu-button');
     const mobileMenu = document.getElementById('mobile-menu');
 
@@ -151,7 +159,7 @@ import { SITE_TITLE, CATEGORIES, GITHUB_URL } from '../consts';
         mobileMenuButton.setAttribute('aria-expanded', String(next));
         mobileMenu.classList.toggle('hidden', !next);
       };
-      mobileMenuButton.addEventListener('click', toggleMobileMenu);
+      mobileMenuButton.addEventListener('click', toggleMobileMenu, { signal });
     }
 
     const desktopButton = document.getElementById('desktop-category-button');
@@ -208,12 +216,12 @@ import { SITE_TITLE, CATEGORIES, GITHUB_URL } from '../consts';
         }
       };
 
-      desktopButton.addEventListener('click', toggleMenu);
-      desktopButton.addEventListener('keydown', handleArrowDown);
-      desktopMenu.addEventListener('keydown', handleEscape);
-      document.addEventListener('click', handleOutsideClick);
+      desktopButton.addEventListener('click', toggleMenu, { signal });
+      desktopButton.addEventListener('keydown', handleArrowDown, { signal });
+      desktopMenu.addEventListener('keydown', handleEscape, { signal });
+      document.addEventListener('click', handleOutsideClick, { signal });
     }
   }
 
-  document.addEventListener('DOMContentLoaded', initHeader);
+  document.addEventListener('astro:page-load', initHeader);
 </script>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -25,6 +25,7 @@ const iso = post.data.pubDate.toISOString().slice(0, 10);
             loading="lazy"
             sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 384px"
             src={post.data.heroImage}
+            transition:name={`hero-${post.id.replaceAll('/', '-')}`}
             width={400}
             widths={[400, 600, 800]}
           />

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -98,7 +98,17 @@ const tocHeadings = headings.filter(heading => heading.depth >= 2 && heading.dep
 </style>
 
 <script>
+  let tocObserver: IntersectionObserver | undefined;
+  let tocAbortController: AbortController | undefined;
+
   function initTableOfContents() {
+    // astro:page-load はページ遷移のたびに発火するため、前回のIntersectionObserver
+    // とイベントリスナーを破棄してから再登録する（冪等化）
+    tocObserver?.disconnect();
+    tocAbortController?.abort();
+    tocAbortController = new AbortController();
+    const { signal } = tocAbortController;
+
     const tocLinks = document.querySelectorAll('.toc-link');
     // 目次の対象は記事本文の見出しのみ（関連記事などページ内の他の見出しを除外）
     const headings = document.querySelectorAll('.prose h2, .prose h3, .prose h4');
@@ -106,7 +116,7 @@ const tocHeadings = headings.filter(heading => heading.depth >= 2 && heading.dep
     if (tocLinks.length === 0 || headings.length === 0) return;
 
     // Create intersection observer for scroll-linked highlighting
-    const observer = new IntersectionObserver(
+    const observer = (tocObserver = new IntersectionObserver(
       entries => {
         entries.forEach(entry => {
           const id = entry.target.id;
@@ -131,7 +141,7 @@ const tocHeadings = headings.filter(heading => heading.depth >= 2 && heading.dep
         rootMargin: '-20% 0% -35% 0%',
         threshold: 0,
       }
-    );
+    ));
 
     // Observe all headings
     headings.forEach(heading => {
@@ -142,27 +152,31 @@ const tocHeadings = headings.filter(heading => heading.depth >= 2 && heading.dep
 
     // Smooth scroll for TOC links
     tocLinks.forEach(link => {
-      link.addEventListener('click', e => {
-        e.preventDefault();
-        const targetId = link.getAttribute('data-heading-id');
+      link.addEventListener(
+        'click',
+        e => {
+          e.preventDefault();
+          const targetId = link.getAttribute('data-heading-id');
 
-        if (targetId) {
-          const targetElement = document.getElementById(targetId);
+          if (targetId) {
+            const targetElement = document.getElementById(targetId);
 
-          if (targetElement) {
-            const headerOffset = 80; // Account for sticky header
-            const elementPosition = targetElement.getBoundingClientRect().top;
-            const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+            if (targetElement) {
+              const headerOffset = 80; // Account for sticky header
+              const elementPosition = targetElement.getBoundingClientRect().top;
+              const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
 
-            window.scrollTo({
-              top: offsetPosition,
-              behavior: 'smooth',
-            });
+              window.scrollTo({
+                top: offsetPosition,
+                behavior: 'smooth',
+              });
+            }
           }
-        }
-      });
+        },
+        { signal }
+      );
     });
   }
 
-  document.addEventListener('DOMContentLoaded', initTableOfContents);
+  document.addEventListener('astro:page-load', initTableOfContents);
 </script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -102,18 +102,32 @@
     }
   });
 
-  document.addEventListener('DOMContentLoaded', () => {
+  let themeToggleAbortController: AbortController | undefined;
+
+  function initThemeToggle() {
+    // astro:page-load はページ遷移のたびに発火し、ボタン自体もページスワップで
+    // 新しいDOMノードに置き換わるため、前回のリスナーを破棄してから再登録する
+    themeToggleAbortController?.abort();
+    themeToggleAbortController = new AbortController();
+    const { signal } = themeToggleAbortController;
+
     const button = document.getElementById('theme-toggle');
     if (button) {
-      button.addEventListener('click', () => {
-        const newTheme = getThemePreference() === 'dark' ? 'light' : 'dark';
-        if (window.__theme) {
-          window.__theme.setItem('theme', newTheme);
-        } else {
-          safeSetItem('theme', newTheme);
-        }
-        applyTheme();
-      });
+      button.addEventListener(
+        'click',
+        () => {
+          const newTheme = getThemePreference() === 'dark' ? 'light' : 'dark';
+          if (window.__theme) {
+            window.__theme.setItem('theme', newTheme);
+          } else {
+            safeSetItem('theme', newTheme);
+          }
+          applyTheme();
+        },
+        { signal }
+      );
     }
-  });
+  }
+
+  document.addEventListener('astro:page-load', initThemeToggle);
 </script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -97,6 +97,7 @@ const ogImageHeight = heroImage ? heroImage.height : 630;
             loading="eager"
             sizes="100vw"
             src={heroImage}
+            transition:name={`hero-${slug.replaceAll('/', '-')}`}
             width={1200}
             widths={[640, 960, 1200]}
           />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import BaseHead from '@/components/BaseHead.astro';
 import Header from '@/components/Header.astro';
 import Footer from '@/components/Footer.astro';
+import { ClientRouter } from 'astro:transitions';
 import '@/styles/global.css';
 
 import type { ImageMetadata } from 'astro';
@@ -59,9 +60,14 @@ const { title, description, image, ogSlug, robots } = Astro.props;
           window.__theme = { getPreference, apply, getItem: safeGetItem, setItem: safeSetItem };
 
           apply();
+
+          // ClientRouterのページスワップ後、<html>のdarkクラスが新ページの
+          // サーバーHTML（クラス無し）に置き換わって消えるため再適用する
+          document.addEventListener('astro:after-swap', apply);
         })();
       </script>
     </BaseHead>
+    <ClientRouter />
   </head>
   <body class="min-h-full flex flex-col bg-surface text-ink">
     <!-- Logbook background effects (dot grid + gradient orb) -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -68,6 +68,16 @@
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+
+  /* 上の `*` セレクタは view transition 疑似要素には届かないため個別に無効化する。
+     AstroのClientRouter（astro/components/ClientRouter.astro が読み込む
+     viewtransitions.css）は `@media (prefers-reduced-motion)` で同等のブロックを
+     自動注入済みだが、保険として明示しておく。 */
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## 概要

デザイン刷新プロジェクトの最終Phase 4です。Astroの `<ClientRouter />` でクライアントサイド遷移を導入し、一覧カードのヒーロー画像が記事ページのヒーローへモーフする遷移を実現します。

## 変更内容

### View Transitions
- `Layout.astro` の `<head>` に `<ClientRouter />` を追加
- heroImageを持つ記事の `<Image>`（PostCard / FeaturedPostCard / BlogPost記事ヒーロー）に `transition:name={`hero-${post.id.replaceAll('/', '-')}`}` を付与（post.idのスラッシュはview-transition-nameとして不正なため置換）
- OGPフォールバックサムネイルには付与しない（記事ページ側にモーフ先のヒーローが存在しないため）
- 同一ページ内の名前衝突なしをビルド出力で確認済み（関連記事は現在記事除外・重複なし、トップはスライスが非重複）

### クライアントサイド遷移へのスクリプト対応
- **テーマ**: ページスワップで `<html>` の `dark` クラスが消えるため、`astro:after-swap` で再適用（インラインテーマスクリプトに1行追加）
- **Header / ThemeToggle / TableOfContents**: `DOMContentLoaded` → `astro:page-load` に移行。遷移のたびにinitが再実行されるため、AbortController（+ TOCはIntersectionObserverの `disconnect()`）でリスナー蓄積を防ぐ冪等化を実施
- dev専用エディタページも同じ `Layout.astro` を使用しているためフォールバック不要と確認

### reduced-motion
- AstroのClientRouterが `@media (prefers-reduced-motion)` での無効化を組み込みで持つことを確認（`astro/components/viewtransitions.css`）。保険としてglobal.cssのreduced-motionブロックにもview-transition疑似要素の無効化を明示

## 検証

- [x] `npm run lint:check` / `npm run typecheck` / `npm test`（33件） / `npm run build` すべてパス
- [x] `dist/client/index.html` に `astro-view-transitions-enabled` メタとhero有り4記事の `view-transition-name` を確認、OGPフォールバックには無いことを確認
- [x] 記事ページ（札幌）のヒーローがカード側と同名 `hero-2025-08-2025-08-30-went-to-sapporo-racecource` でモーフ成立を確認

## ⚠️ デプロイ後の確認事項

**AdSense自動広告**: クライアントサイド遷移では2ページ目以降の広告挿入が保証されません（自動広告はSPA非対応のため）。本番デプロイ後、ページ遷移を挟んだ広告表示を確認してください。問題があればClientRouterの除去（1行）で即座に戻せます。

## これでデザイン刷新（全4フェーズ）完了 🎉

1. #319 セマンティックトークン + ティールアクセント
2. #320 トップページのログブック再構成
3. #321 記事ページの読書体験
4. 本PR View Transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)