### PR TITLE
fix(og): OGP画像タイトルの切り詰めを書記素クラスタ単位に修正

### DIFF
--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -2,6 +2,7 @@ import satori from 'satori';
 import sharp from 'sharp';
 import { getCollection, type CollectionEntry } from 'astro:content';
 import { CATEGORIES } from '../../consts';
+import { truncateGraphemes } from '../../utils/truncate';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { APIContext } from 'astro';
@@ -158,7 +159,7 @@ export async function GET({ params, props }: APIContext<Props>) {
             whiteSpace: 'pre-wrap',
           },
         },
-        title.length > 50 ? title.substring(0, 50) + '…' : title
+        truncateGraphemes(title, 50)
       ),
       description
         ? h(
@@ -171,7 +172,7 @@ export async function GET({ params, props }: APIContext<Props>) {
                 textAlign: 'center',
               },
             },
-            description.length > 80 ? description.substring(0, 80) + '…' : description
+            truncateGraphemes(description, 80)
           )
         : null,
       h(

--- a/src/utils/truncate.ts
+++ b/src/utils/truncate.ts
@@ -1,0 +1,31 @@
+const segmenter = new Intl.Segmenter('ja', { granularity: 'grapheme' });
+
+/**
+ * 文字列を書記素クラスタ（見た目上の1文字）単位で切り詰める
+ *
+ * String.prototype.substring はUTF-16コードユニット単位で切るため、
+ * サロゲートペア（絵文字など）やZWJ合成絵文字を途中で破壊しうる。
+ * Intl.Segmenter で書記素単位に分割してから切り詰めることでこれを防ぐ。
+ *
+ * @param text 対象の文字列
+ * @param maxGraphemes 最大書記素数
+ * @param ellipsis 切り詰め時に付与する省略記号（デフォルト: '…'）
+ * @returns 書記素数が maxGraphemes 以下ならそのまま、超える場合は先頭
+ *          maxGraphemes 書記素 + 省略記号
+ */
+export function truncateGraphemes(
+  text: string,
+  maxGraphemes: number,
+  ellipsis: string = '…'
+): string {
+  const graphemes = [...segmenter.segment(text)];
+  if (graphemes.length <= maxGraphemes) {
+    return text;
+  }
+  return (
+    graphemes
+      .slice(0, maxGraphemes)
+      .map(({ segment }) => segment)
+      .join('') + ellipsis
+  );
+}

--- a/test/truncate.test.ts
+++ b/test/truncate.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { truncateGraphemes } from '../src/utils/truncate.ts';
+
+test('truncateGraphemes: 切り詰め不要な短い文字列はそのまま返す', () => {
+  assert.equal(truncateGraphemes('短いタイトル', 50), '短いタイトル');
+});
+
+test('truncateGraphemes: 最大長ちょうどの文字列は省略記号を付けない', () => {
+  assert.equal(truncateGraphemes('あ'.repeat(50), 50), 'あ'.repeat(50));
+});
+
+test('truncateGraphemes: 通常の日本語タイトルは指定文字数で切り詰めて省略記号を付ける', () => {
+  const title = 'あ'.repeat(60);
+  assert.equal(truncateGraphemes(title, 50), 'あ'.repeat(50) + '…');
+});
+
+test('truncateGraphemes: 切り詰め境界のサロゲートペア絵文字を破壊しない', () => {
+  // '🐴' はサロゲートペア（UTF-16で2コードユニット）。
+  // 49文字 + '🐴' で substring(0, 50) だと上位サロゲートだけが残り文字化けする。
+  const title = 'あ'.repeat(49) + '🐴' + '以降は切り捨てられる部分';
+  const truncated = truncateGraphemes(title, 50);
+  assert.equal(truncated, 'あ'.repeat(49) + '🐴…');
+  // substring ベースの旧実装では末尾が孤立サロゲートになっていたことの対比
+  assert.notEqual(truncated, title.substring(0, 50) + '…');
+});
+
+test('truncateGraphemes: ZWJ合成絵文字を1文字として数え、分解しない', () => {
+  // 👨‍👩‍👧‍👦 は4つの絵文字をZWJで結合した1書記素（UTF-16で11コードユニット）
+  const family = '👨‍👩‍👧‍👦';
+  const title = 'あ'.repeat(49) + family + '以降は切り捨てられる部分';
+  assert.equal(truncateGraphemes(title, 50), 'あ'.repeat(49) + family + '…');
+});
+
+test('truncateGraphemes: ZWJ合成絵文字が境界を超える場合は丸ごと落とす', () => {
+  const family = '👨‍👩‍👧‍👦';
+  const title = 'あ'.repeat(50) + family;
+  assert.equal(truncateGraphemes(title, 50), 'あ'.repeat(50) + '…');
+});
+
+test('truncateGraphemes: 省略記号を指定できる', () => {
+  assert.equal(truncateGraphemes('abcdef', 3, '...'), 'abc...');
+});


### PR DESCRIPTION
## 概要

コードレビュー残課題の対応です。OGP画像生成（`src/pages/og/[...slug].png.ts`）のタイトル・説明文の切り詰めが `substring` ベース（UTF-16コードユニット単位）だったため、50/80文字境界にサロゲートペア絵文字やZWJ合成絵文字が来ると文字を破壊して孤立サロゲートを生成しうる潜在バグを修正しました。

## 変更内容

- `src/utils/truncate.ts`（新規）: `Intl.Segmenter`（granularity: 'grapheme'）による書記素クラスタ単位の切り詰め関数 `truncateGraphemes` を追加
- `src/pages/og/[...slug].png.ts`: タイトル（50文字）・説明文（80文字）の切り詰めを `truncateGraphemes` に置換。表示仕様（切り詰め長・省略記号 `…`）は従来どおり
- `test/truncate.test.ts`（新規）: 境界サロゲートペア・ZWJ合成絵文字・通常日本語など7ケース

## テスト

- [x] `npm test`: 40 pass / 0 fail（新規7件含む）
- [x] `npm run lint:check` / `npm run format:check`
- [x] `npm run typecheck`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)