### PR TITLE
fix: 内部リンクの末尾スラッシュを統一

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,9 @@ const MDX_REHYPE_PLUGINS = [[rehypeLinkPreview, { site: SITE }]];
 // https://astro.build/config
 export default defineConfig({
   site: SITE,
+  // NOTE: trailingSlash: 'always' は /og/[...slug].png.ts のprerenderで
+  // `/og/...png/` が要求されてNoMatchingStaticPathFoundになるため設定しない。
+  // 内部リンク側を末尾スラッシュ付きに統一して対応している。
   output: 'server',
   adapter: cloudflare({
     imageService: 'compile',

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,7 +16,7 @@ import { SITE_TITLE, CATEGORIES, GITHUB_URL } from '../consts';
         </h1>
         <div class="hidden md:flex items-center space-x-1">
           <HeaderLink href="/">ホーム</HeaderLink>
-          <HeaderLink href="/blog">ブログ</HeaderLink>
+          <HeaderLink href="/blog/">ブログ</HeaderLink>
 
           <!-- Categories Dropdown -->
           <div class="relative">
@@ -52,7 +52,7 @@ import { SITE_TITLE, CATEGORIES, GITHUB_URL } from '../consts';
             </div>
           </div>
 
-          <HeaderLink href="/about">プロフィール</HeaderLink>
+          <HeaderLink href="/about/">プロフィール</HeaderLink>
         </div>
       </div>
 
@@ -96,7 +96,7 @@ import { SITE_TITLE, CATEGORIES, GITHUB_URL } from '../consts';
     >
       <div class="flex flex-col space-y-2">
         <HeaderLink href="/">ホーム</HeaderLink>
-        <HeaderLink href="/blog">ブログ</HeaderLink>
+        <HeaderLink href="/blog/">ブログ</HeaderLink>
 
         <!-- Mobile Categories -->
         <div class="px-3 py-2">
@@ -115,7 +115,7 @@ import { SITE_TITLE, CATEGORIES, GITHUB_URL } from '../consts';
           </div>
         </div>
 
-        <HeaderLink href="/about">プロフィール</HeaderLink>
+        <HeaderLink href="/about/">プロフィール</HeaderLink>
         <div class="flex items-center space-x-4 pt-4">
           <a
             aria-label="GitHub"

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -6,7 +6,12 @@ type Props = HTMLAttributes<'a'>;
 const { href, class: className, ...props } = Astro.props;
 const pathname = Astro.url.pathname.replace(import.meta.env.BASE_URL, '');
 const subpath = pathname.match(/[^\/]+/g);
-const isActive = href === pathname || href === '/' + (subpath?.[0] || '');
+// 内部リンクは末尾スラッシュ付きに統一しているため、比較前に正規化する
+const normalize = (path: string) => (path.endsWith('/') ? path : `${path}/`);
+const isActive =
+  typeof href === 'string' &&
+  (normalize(href) === normalize(`/${pathname.replace(/^\/+/, '')}`) ||
+    normalize(href) === '/' + (subpath?.[0] ? `${subpath[0]}/` : ''));
 ---
 
 <a

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -229,7 +229,7 @@ const ogImageHeight = heroImage ? heroImage.height : 630;
                 <div class="flex items-center gap-4">
                   <a
                     class="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium transition-colors"
-                    href="/blog"
+                    href="/blog/"
                   >
                     ← ブログ一覧に戻る
                   </a>

--- a/src/pages/category/[category].astro
+++ b/src/pages/category/[category].astro
@@ -84,7 +84,7 @@ const structuredCategoryList = jsonLdStringify({
         <div class="flex flex-wrap justify-center gap-3">
           <a
             class="px-4 py-2 rounded-full text-sm font-medium transition-colors duration-200 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
-            href="/blog"
+            href="/blog/"
           >
             すべて ({allPosts.length})
           </a>
@@ -128,7 +128,7 @@ const structuredCategoryList = jsonLdStringify({
             </svg>
             <a
               class="hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
-              href="/blog"
+              href="/blog/"
             >
               ブログ
             </a>
@@ -158,7 +158,7 @@ const structuredCategoryList = jsonLdStringify({
             </p>
             <a
               class="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium mt-4 inline-block"
-              href="/blog"
+              href="/blog/"
             >
               すべての記事を見る
             </a>


### PR DESCRIPTION
## 概要

コードレビュー残課題の対応です。canonical URLは末尾スラッシュ付きに正規化済みでしたが、テンプレート内のhrefに `/blog` と `/category/写真/` が混在していたため、ページ系の内部リンクをすべて末尾スラッシュ付きに統一しました。

## 変更内容

- `Header.astro` / `BlogPost.astro` / `category/[category].astro`: `/blog` → `/blog/`、`/about` → `/about/`（計8箇所）
- `HeaderLink.astro`: アクティブ判定を末尾スラッシュ正規化して比較するよう修正（従来ロジックはスラッシュ付きhrefにマッチしないため）
- `astro.config.mjs`: `trailingSlash: 'always'` を設定しない理由をコメントで明記

棚卸しの結果、その他のリンク（PostCard・前後記事ナビ・カテゴリバッジ・ページネーション・RSSのlink/guid・JSON-LD）はすべて既に末尾スラッシュ付きでした。`/rss.xml`・`/sitemap-index.xml`・`/og/*.png` などのファイル的URLは対象外です。

## trailingSlash: 'always' を見送った理由

設定してビルドすると `/og/[...slug].png.ts` のprerenderで `/og/....png/` が要求され `NoMatchingStaticPathFound` で失敗するため。Workers assetsのデフォルト（auto-trailing-slash）が既に `/blog` → `/blog/` へ307リダイレクトするので、設定なしでもURLは実質統一されます。

## 検証（wrangler devでのpreview）

- `/blog` → 307 → `/blog/`（200）、`/about`・`/blog/page/2` も同様
- `/category/写真/` → 200
- `/rss.xml`・`/sitemap-index.xml`・`/og/*.png` → 200（リダイレクトなし）

## テスト

- [x] `npm run build` 成功
- [x] `npm test`: 33件全パス
- [x] `npm run lint:check` / `npm run format:check` / `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)