### PR TITLE
fix(images): ビルド時にsharpで実際に画像を縮小・WebP変換する

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,6 +21,12 @@ export default defineConfig({
     imageService: 'compile',
     prerenderEnvironment: 'node',
   }),
+  image: {
+    // imageService: 'compile' + prerenderEnvironment: 'node' の組み合わせでは
+    // アダプタのsharp差し替えが働かず、no-opサービスが元画像を複製するだけになる。
+    // 詳細は src/lib/build-image-service.mjs のコメントを参照。
+    service: { entrypoint: './src/lib/build-image-service.mjs' },
+  },
   markdown: {
     rehypePlugins: MARKDOWN_REHYPE_PLUGINS,
   },

--- a/src/lib/build-image-service.mjs
+++ b/src/lib/build-image-service.mjs
@@ -1,0 +1,13 @@
+// ビルド時（Nodeプリレンダ環境）に実際の画像リサイズ・WebP変換を行うための
+// sharpサービスのラッパー。
+//
+// @astrojs/cloudflare は imageService: 'compile' のとき、entrypoint文字列が
+// 'astro/assets/services/sharp' そのものだと no-op の image-service-workerd に
+// 強制的に差し替える（workerdでsharpが動かない前提の防御）。しかし本プロジェクトは
+// prerenderEnvironment: 'node' でプリレンダするため sharp が問題なく動く。
+// このファイルを経由して entrypoint 文字列を変えることで強制差し替えを回避し、
+// widths 指定どおりに縮小された本物のWebPを生成させる。
+//
+// 注意: @astrojs/cloudflare 更新時はこの回避策が引き続き機能するか
+// （srcset候補が実際に縮小されているか）を確認すること。
+export { default } from 'astro/assets/services/sharp';


### PR DESCRIPTION
## 概要

デザイン刷新の持ち越し課題「`imageService: 'compile'` がsrcset候補を縮小しない転送量問題」の修正です。調査の結果、想定よりずっと深刻でした。

## 問題（調査エージェントによるビルド実測）

`imageService: 'compile'` + `prerenderEnvironment: 'node'` の組み合わせでは、@astrojs/cloudflareのsharp差し替え機構（`collectStaticImages`）が `prerenderEnvironment: 'workerd'` のときしか有効化されず、no-opの `image-service-workerd`（入力バッファをそのまま返す）が全画像を「生成」していました。その結果:

- srcset候補は**全てファイル名だけ違う元寸コピー**（例: ヒーロー画像は640w/960w/1200wどれも2452x1846・972KB）
- `.webp` 拡張子だが**中身はJPEGのまま**（formatを偽申告）
- `dist/client/_astro` は画像511個・260MB、うち**209MBが純粋な重複**
- モバイルで記事を開くと640w候補として972KBのJPEGが配信されていた（正しく処理すれば46KB）

## 修正

sharpサービスを再エクスポートするラッパー `src/lib/build-image-service.mjs` を `image.service` に指定。アダプタの `hasUserImageService()` は entrypoint文字列 `'astro/assets/services/sharp'` を意図的に除外してno-opへ強制差し替えするため、ラッパー経由でentrypoint文字列を変えて回避します。本プロジェクトはNodeでプリレンダするのでsharpは問題なく動作します。

## 効果（ビルド実測）

- `dist/client/_astro`: **260MB → 31MB（88%減）**
- ヒーロー画像srcset: 640w=640x482/46KB、960w=960x722/102KB、1200w=1200x903/152KB の本物のWebPに
- キャッシュキーにentrypointが含まれるため再生成は自動、手動クリア不要

## 注意事項

- アダプタが本来想定していない構成のため、`@astrojs/cloudflare` 更新時はsrcset候補が実際に縮小されているかの確認が必要（ラッパーのコメントに明記済み）
- 根本対応としては `prerenderEnvironment: 'workerd'` に戻すのが正攻法だが、OGP生成（satori+sharp+node:fs）の作り直しが必要になるため見送り。upstreamバグ報告に値する挙動

## テスト

- [x] `npm run build` 成功（全ページprerender、画像最適化ログで縮小を確認）
- [x] `npm test`: 33件全パス
- [x] `npm run lint:check` / `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)