### PR TITLE
feat: 記事内画像のライトボックス拡大表示を追加（PhotoSwipe v5）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.2",
         "astro": "^7.0.4",
+        "photoswipe": "^5.4.4",
         "satori": "^0.26.0",
         "sharp": "^0.35.2",
         "tailwindcss": "^4.1.17"
@@ -9397,6 +9398,15 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/photoswipe": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/photoswipe/-/photoswipe-5.4.4.tgz",
+      "integrity": "sha512-WNFHoKrkZNnvFFhbHL93WDkW3ifwVOXSW3w1UuZZelSmgXpIGiZSNlZJq37rR8YejqME2rHs9EhH9ZvlvFH2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.12.0"
+      }
     },
     "node_modules/piccolore": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.2",
     "astro": "^7.0.4",
+    "photoswipe": "^5.4.4",
     "satori": "^0.26.0",
     "sharp": "^0.35.2",
     "tailwindcss": "^4.1.17"

--- a/src/components/ImageLightbox.astro
+++ b/src/components/ImageLightbox.astro
@@ -1,0 +1,90 @@
+---
+import 'photoswipe/style.css';
+---
+
+<style>
+  @reference "tailwindcss";
+
+  :global(.prose img.lightbox-target) {
+    cursor: zoom-in;
+  }
+</style>
+
+<script>
+  import PhotoSwipeLightbox from 'photoswipe/lightbox';
+  import type { SlideData } from 'photoswipe';
+  import { buildLightboxItemData } from '@/utils/lightbox';
+
+  let lightbox: PhotoSwipeLightbox | undefined;
+  let lightboxAbortController: AbortController | undefined;
+
+  function initImageLightbox() {
+    // astro:page-load はページ遷移のたびに発火するため、前回のPhotoSwipeインスタンス
+    // とイベントリスナーを破棄してから再登録する（冪等化）
+    lightbox?.destroy();
+    lightboxAbortController?.abort();
+    lightboxAbortController = new AbortController();
+    const { signal } = lightboxAbortController;
+
+    const candidates = Array.from(document.querySelectorAll<HTMLImageElement>('.prose img')).filter(
+      img => !img.closest('a')
+    );
+
+    if (candidates.length === 0) return;
+
+    candidates.forEach(img => {
+      img.classList.add('lightbox-target');
+      // キーボード操作で拡大表示を開けるようにする（クリック相当）
+      img.setAttribute('role', 'button');
+      img.tabIndex = 0;
+      img.setAttribute('aria-label', img.alt ? `${img.alt}（拡大表示）` : '画像を拡大表示');
+    });
+
+    const dataSource: SlideData[] = candidates.map(img => {
+      const srcset = img.getAttribute('srcset');
+      const src = img.currentSrc || img.getAttribute('src') || img.src;
+      const widthAttr = img.getAttribute('width');
+      const heightAttr = img.getAttribute('height');
+
+      const built = buildLightboxItemData(srcset, src, widthAttr, heightAttr);
+
+      let { width, height } = built;
+      if (width === undefined || height === undefined) {
+        if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+          width = img.naturalWidth;
+          height = img.naturalHeight;
+        }
+      }
+
+      return {
+        src: built.src,
+        width,
+        height,
+        msrc: img.currentSrc || img.src,
+        element: img,
+      };
+    });
+
+    const instance = (lightbox = new PhotoSwipeLightbox({
+      pswpModule: () => import('photoswipe'),
+    }));
+    instance.init();
+
+    candidates.forEach((img, index) => {
+      const open = (event: Event) => {
+        event.preventDefault();
+        instance.loadAndOpen(index, dataSource);
+      };
+      img.addEventListener('click', open, { signal });
+      img.addEventListener(
+        'keydown',
+        event => {
+          if (event.key === 'Enter' || event.key === ' ') open(event);
+        },
+        { signal }
+      );
+    });
+  }
+
+  document.addEventListener('astro:page-load', initImageLightbox);
+</script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,6 +4,7 @@ import Layout from './Layout.astro';
 import FormattedDate from '@/components/FormattedDate.astro';
 import { Image } from 'astro:assets';
 import TableOfContents from '@/components/TableOfContents.astro';
+import ImageLightbox from '@/components/ImageLightbox.astro';
 import RelatedPosts from '@/components/RelatedPosts.astro';
 import { getRelatedPosts } from '@/utils/relatedPosts';
 import { getAllPosts } from '@/utils/posts';
@@ -152,6 +153,7 @@ const ogImageHeight = heroImage ? heroImage.height : 630;
               <div class="prose prose-lg dark:prose-invert max-w-[42rem]">
                 <slot />
               </div>
+              <ImageLightbox />
             </div>
 
             <!-- ここにTweetButtonを配置 -->

--- a/src/utils/lightbox.ts
+++ b/src/utils/lightbox.ts
@@ -1,0 +1,138 @@
+/**
+ * 記事本文中の `<img>` から PhotoSwipe 用のライトボックスアイテムを組み立てるための
+ * 純粋関数群。DOMに依存しないため、node:test でjsdom無しにユニットテストできる。
+ */
+
+/** srcsetの1エントリをパースした結果 */
+interface SrcsetCandidate {
+  url: string;
+  width: number;
+}
+
+/**
+ * `srcset` 属性文字列をパースし、有効な候補（url + 幅ディスクリプタ）の配列を返す。
+ *
+ * `srcset` の形式は `"url1 640w, url2 960w, url3 1200w"` のようなカンマ区切り。
+ * `w` ディスクリプタを持たない・幅が0以下などの不正なエントリは無視する。
+ *
+ * @param srcset `<img>` の `srcset` 属性値（未設定・空文字列も許容）
+ * @returns パースできた候補の配列（元の記述順）。全て不正なら空配列
+ */
+function parseSrcsetCandidates(srcset: string | null | undefined): SrcsetCandidate[] {
+  if (!srcset) return [];
+
+  const candidates: SrcsetCandidate[] = [];
+
+  for (const rawEntry of srcset.split(',')) {
+    const entry = rawEntry.trim();
+    if (!entry) continue;
+
+    // 空白区切りで "url widthDescriptor" の2トークンを期待する
+    const parts = entry.split(/\s+/);
+    if (parts.length < 2) continue;
+
+    const url = parts[0];
+    const descriptor = parts[1];
+    const match = /^(\d+(?:\.\d+)?)w$/.exec(descriptor);
+    if (!url || !match) continue;
+
+    const width = Number(match[1]);
+    if (!Number.isFinite(width) || width <= 0) continue;
+
+    candidates.push({ url, width });
+  }
+
+  return candidates;
+}
+
+/**
+ * `srcset` 属性文字列をパースし、最も幅の大きい候補のURLを返す。
+ *
+ * 不正な・パースできないエントリは無視する。複数の候補が最大幅で同点の場合は
+ * 記述順で最初に現れたものを返す。
+ *
+ * @param srcset `<img>` の `srcset` 属性値（未設定・空文字列も許容）
+ * @returns 最大幅の候補URL。パース可能なエントリが無ければ `undefined`
+ */
+export function parseSrcsetMaxWidthUrl(srcset: string | null | undefined): string | undefined {
+  const candidates = parseSrcsetCandidates(srcset);
+  if (candidates.length === 0) return undefined;
+
+  return candidates.reduce((best, current) => (current.width > best.width ? current : best)).url;
+}
+
+/**
+ * `srcset` から選んだ候補の幅と、`<img>` の `width`/`height` 属性値（アスペクト比の
+ * 元ネタ）から、ライトボックスで表示すべき実寸の width/height を計算する。
+ *
+ * `width`/`height` 属性がどちらも正の数値として解釈できない場合は、アスペクト比を
+ * 決定できないため `undefined` を返す（呼び出し側は naturalWidth/naturalHeight への
+ * フォールバックをブラウザ環境で行う）。
+ *
+ * @param candidateWidth srcsetから選ばれた最大幅候補の幅（px）
+ * @param widthAttr `<img>` の `width` 属性値（文字列 or 数値、未設定・不正値も許容）
+ * @param heightAttr `<img>` の `height` 属性値（文字列 or 数値、未設定・不正値も許容）
+ * @returns 計算済みの `{ width, height }`。計算できない場合は `undefined`
+ */
+export function computeScaledDimensions(
+  candidateWidth: number,
+  widthAttr: string | number | null | undefined,
+  heightAttr: string | number | null | undefined
+): { width: number; height: number } | undefined {
+  const attrWidth = toPositiveNumber(widthAttr);
+  const attrHeight = toPositiveNumber(heightAttr);
+
+  if (attrWidth === undefined || attrHeight === undefined) return undefined;
+  if (!Number.isFinite(candidateWidth) || candidateWidth <= 0) return undefined;
+
+  const aspectRatio = attrHeight / attrWidth;
+  return {
+    width: candidateWidth,
+    height: Math.round(candidateWidth * aspectRatio),
+  };
+}
+
+/**
+ * 1枚の `<img>` に対応するPhotoSwipeの `dataSource` アイテム（の一部）を組み立てる。
+ *
+ * `src` は `srcset` から解決した最大幅候補を優先し、無ければ渡された `src`
+ * （`currentSrc` 等）にフォールバックする。`width`/`height`
+ * は `computeScaledDimensions` で計算できた場合のみ含め、できなければ
+ * `undefined`（呼び出し側でnaturalWidth/naturalHeightへフォールバック）。
+ *
+ * @param srcset `<img>` の `srcset` 属性値
+ * @param src `<img>` の `currentSrc` あるいは `src` 属性値（srcset未解決時のフォールバック）
+ * @param widthAttr `<img>` の `width` 属性値
+ * @param heightAttr `<img>` の `height` 属性値
+ * @returns `{ src, width, height }`。`src` が一切解決できない場合は空文字列を返す
+ */
+export function buildLightboxItemData(
+  srcset: string | null | undefined,
+  src: string | null | undefined,
+  widthAttr: string | number | null | undefined,
+  heightAttr: string | number | null | undefined
+): { src: string; width: number | undefined; height: number | undefined } {
+  const candidates = parseSrcsetCandidates(srcset);
+  const best =
+    candidates.length > 0 ? candidates.reduce((a, b) => (b.width > a.width ? b : a)) : undefined;
+
+  const resolvedSrc = best?.url ?? src ?? '';
+
+  const scaled = best ? computeScaledDimensions(best.width, widthAttr, heightAttr) : undefined;
+
+  return {
+    src: resolvedSrc,
+    width: scaled?.width,
+    height: scaled?.height,
+  };
+}
+
+/**
+ * 文字列または数値を正の有限数に変換する。変換できなければ `undefined`。
+ */
+function toPositiveNumber(value: string | number | null | undefined): number | undefined {
+  if (value === null || value === undefined) return undefined;
+  const num = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(num) || num <= 0) return undefined;
+  return num;
+}

--- a/test/lightbox.test.ts
+++ b/test/lightbox.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildLightboxItemData,
+  computeScaledDimensions,
+  parseSrcsetMaxWidthUrl,
+} from '../src/utils/lightbox.ts';
+
+test('parseSrcsetMaxWidthUrl: 通常のsrcsetから最大幅のURLを選ぶ', () => {
+  const srcset = 'a.webp 640w, b.webp 960w, c.webp 1200w';
+  assert.equal(parseSrcsetMaxWidthUrl(srcset), 'c.webp');
+});
+
+test('parseSrcsetMaxWidthUrl: 記述順が逆でも最大幅のURLを選ぶ', () => {
+  const srcset = 'c.webp 1200w, a.webp 640w, b.webp 960w';
+  assert.equal(parseSrcsetMaxWidthUrl(srcset), 'c.webp');
+});
+
+test('parseSrcsetMaxWidthUrl: エントリが1件のみでもそれを返す', () => {
+  assert.equal(parseSrcsetMaxWidthUrl('only.webp 800w'), 'only.webp');
+});
+
+test('parseSrcsetMaxWidthUrl: 前後・区切りの余分な空白を許容する', () => {
+  const srcset = '  a.webp   640w  ,   b.webp 960w  ';
+  assert.equal(parseSrcsetMaxWidthUrl(srcset), 'b.webp');
+});
+
+test('parseSrcsetMaxWidthUrl: nullやundefinedはundefinedを返す', () => {
+  assert.equal(parseSrcsetMaxWidthUrl(null), undefined);
+  assert.equal(parseSrcsetMaxWidthUrl(undefined), undefined);
+});
+
+test('parseSrcsetMaxWidthUrl: 空文字列はundefinedを返す', () => {
+  assert.equal(parseSrcsetMaxWidthUrl(''), undefined);
+});
+
+test('parseSrcsetMaxWidthUrl: wディスクリプタが無いエントリは無視する', () => {
+  const srcset = 'a.webp, b.webp 960w';
+  assert.equal(parseSrcsetMaxWidthUrl(srcset), 'b.webp');
+});
+
+test('parseSrcsetMaxWidthUrl: 不正なディスクリプタ（xやpx等）のエントリは無視する', () => {
+  const srcset = 'a.webp 2x, b.webp 960w, c.webp abcw';
+  assert.equal(parseSrcsetMaxWidthUrl(srcset), 'b.webp');
+});
+
+test('parseSrcsetMaxWidthUrl: 全エントリが不正なら undefined を返す', () => {
+  assert.equal(parseSrcsetMaxWidthUrl('a.webp, b.webp 2x'), undefined);
+});
+
+test('parseSrcsetMaxWidthUrl: 幅が0や負の値のエントリは無視する', () => {
+  const srcset = 'a.webp 0w, b.webp -100w, c.webp 500w';
+  assert.equal(parseSrcsetMaxWidthUrl(srcset), 'c.webp');
+});
+
+test('computeScaledDimensions: 有効なwidth/height属性からアスペクト比を保って計算する', () => {
+  // 元画像が 800x400（アスペクト比 0.5）で、候補幅が1200の場合 -> 高さ600
+  const result = computeScaledDimensions(1200, 800, 400);
+  assert.deepEqual(result, { width: 1200, height: 600 });
+});
+
+test('computeScaledDimensions: 文字列のwidth/height属性も受け付ける', () => {
+  const result = computeScaledDimensions(640, '320', '240');
+  assert.deepEqual(result, { width: 640, height: 480 });
+});
+
+test('computeScaledDimensions: 端数は四捨五入する', () => {
+  // アスペクト比 100/300 = 0.333... -> 640 * 0.333... = 213.33... -> 213
+  const result = computeScaledDimensions(640, 300, 100);
+  assert.deepEqual(result, { width: 640, height: 213 });
+});
+
+test('computeScaledDimensions: width属性が欠落していればundefinedを返す', () => {
+  assert.equal(computeScaledDimensions(640, undefined, 400), undefined);
+});
+
+test('computeScaledDimensions: height属性が欠落していればundefinedを返す', () => {
+  assert.equal(computeScaledDimensions(640, 800, null), undefined);
+});
+
+test('computeScaledDimensions: width/height属性が不正な文字列ならundefinedを返す', () => {
+  assert.equal(computeScaledDimensions(640, 'abc', '400'), undefined);
+});
+
+test('computeScaledDimensions: width/height属性が0や負の値ならundefinedを返す', () => {
+  assert.equal(computeScaledDimensions(640, 0, 400), undefined);
+  assert.equal(computeScaledDimensions(640, 800, -1), undefined);
+});
+
+test('computeScaledDimensions: candidateWidthが0や負の値ならundefinedを返す', () => {
+  assert.equal(computeScaledDimensions(0, 800, 400), undefined);
+  assert.equal(computeScaledDimensions(-100, 800, 400), undefined);
+});
+
+test('buildLightboxItemData: srcsetがあればその最大幅候補をsrcに使い、寸法も計算する', () => {
+  const result = buildLightboxItemData('a.webp 640w, b.webp 1200w', 'fallback.webp', '800', '400');
+  assert.deepEqual(result, { src: 'b.webp', width: 1200, height: 600 });
+});
+
+test('buildLightboxItemData: srcsetが無ければsrcにフォールバックし、寸法はundefined', () => {
+  const result = buildLightboxItemData(undefined, 'plain.webp', '800', '400');
+  assert.deepEqual(result, { src: 'plain.webp', width: undefined, height: undefined });
+});
+
+test('buildLightboxItemData: srcsetがパース不能でもsrcにフォールバックする', () => {
+  const result = buildLightboxItemData('broken-entry', 'plain.webp', '800', '400');
+  assert.deepEqual(result, { src: 'plain.webp', width: undefined, height: undefined });
+});
+
+test('buildLightboxItemData: width/height属性が不正ならsrcsetのURLは使うが寸法はundefined', () => {
+  const result = buildLightboxItemData('a.webp 1200w', 'fallback.webp', undefined, undefined);
+  assert.deepEqual(result, { src: 'a.webp', width: undefined, height: undefined });
+});
+
+test('buildLightboxItemData: srcsetもsrcも無ければ空文字列を返す', () => {
+  const result = buildLightboxItemData(undefined, undefined, undefined, undefined);
+  assert.deepEqual(result, { src: '', width: undefined, height: undefined });
+});


### PR DESCRIPTION
## 概要

ブログ記事本文中の画像をクリック・タップすると拡大表示されるライトボックス機能を PhotoSwipe v5 で実装しました（CLAUDE.md 残課題「画像ギャラリー強化」対応）。

## 変更内容

- **`src/components/ImageLightbox.astro`（新規）**: `.prose` 内の画像を収集し PhotoSwipe ギャラリーとして初期化
  - `<a>` 内の画像（rehype-link-preview のリンクカード含む）は除外
  - ヒーロー画像は `.prose` 外のため対象外（View Transitions のモーフと干渉しない）
  - PhotoSwipe 本体は `pswpModule` で遅延ロード（クリックまで読み込まれない）
  - `astro:page-load` + AbortController + `destroy()` で ClientRouter 遷移に冪等対応
  - a11y: 対象画像に `role="button"` / `tabindex="0"` / `aria-label` を付与し Enter/Space でも開ける
- **`src/utils/lightbox.ts`（新規）**: srcset パースと拡大表示寸法の計算を DOM 非依存の純粋関数に切り出し。拡大時は srcset 最大幅候補（1280px）を使用し、`msrc` に表示中サムネイルを渡してズームアニメーションを滑らかに接続
- **`test/lightbox.test.ts`（新規）**: 上記ロジックのユニットテスト23件
- **`src/layouts/BlogPost.astro`**: `<slot />` 直後に `<ImageLightbox />` を追加
- **`package.json` / `package-lock.json`**: `photoswipe@^5.4.4` 追加（`npx -y npm@10.9.2 install` で実施、lockfile は CI 互換）

## CSP について

PhotoSwipe は npm パッケージとしてバンドルされ self から配信されるため、`public/_headers` の CSP 変更は不要です（ビルド成果物 `photoswipe.esm.*.js` で確認済み）。

## 検証

- [x] `npm run typecheck` / `lint:check` / `format:check` 通過
- [x] `npm test` 63件全パス（新規23件含む）
- [x] `npm run build` 成功、記事HTMLへのスクリプト組み込み・CSSバンドルを確認
- [x] 実機で拡大表示・スワイプ・ピンチズームの動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)