### PR TITLE
feat: image.layout constrained でMarkdown画像をレスポンシブ化

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,6 +29,8 @@ export default defineConfig({
     // アダプタのsharp差し替えが働かず、no-opサービスが元画像を複製するだけになる。
     // 詳細は src/lib/build-image-service.mjs のコメントを参照。
     service: { entrypoint: './src/lib/build-image-service.mjs' },
+    // Markdown ![]() 記法の画像にも自動でsrcset/sizesを付与する(Astro 5.10〜安定化)。
+    layout: 'constrained',
   },
   markdown: {
     rehypePlugins: MARKDOWN_REHYPE_PLUGINS,

--- a/src/components/CaptionedImage.astro
+++ b/src/components/CaptionedImage.astro
@@ -25,7 +25,6 @@ const resolvedWidth = width ?? 1280;
     {...height && { height }}
     class="image"
     format="webp"
-    inferSize={false}
     sizes="(max-width: 1024px) 100vw, 768px"
     widths={[480, 720, 960, 1280]}
   />

--- a/src/components/ImageGrid.astro
+++ b/src/components/ImageGrid.astro
@@ -28,7 +28,6 @@ const sizes = `(max-width: 768px) 100vw, (max-width: 1024px) 50vw, ${Math.round(
           alt={image.alt}
           class="grid-image"
           format="webp"
-          height={400}
           sizes={sizes}
           src={image.src as ImageMetadata}
           width={600}

--- a/src/components/ImageGrid.astro
+++ b/src/components/ImageGrid.astro
@@ -29,7 +29,6 @@ const sizes = `(max-width: 768px) 100vw, (max-width: 1024px) 50vw, ${Math.round(
           class="grid-image"
           format="webp"
           height={400}
-          inferSize={false}
           sizes={sizes}
           src={image.src as ImageMetadata}
           width={600}


### PR DESCRIPTION
## 概要

Astro v5.10で安定化した `image.layout` を導入し、Markdown `![]()` 記法の画像にも自動でsrcset/sizesが付くようにしました。あわせて `CaptionedImage` / `ImageGrid` の不要な `inferSize={false}`（HTMLに無効属性 `inferSize="false"` として漏れていた）を削除しました。

## 変更内容

- `astro.config.mjs`: `image.layout: 'constrained'` を追加（既存の `build-image-service.mjs` 指定は維持）
- `src/components/CaptionedImage.astro` / `src/components/ImageGrid.astro`: `inferSize={false}` を削除

`astro.dev.config.mjs` はベース設定をスプレッド継承しているため変更不要です。

## Before / After（northern-horse-park記事のMarkdown画像）

- Before: srcsetなし、単一webp（933px）のみ
- After: `srcset="...640w, ...750w, ...828w, ...933w"` + `sizes="(min-width: 933px) 933px, 100vw"`

## 検証

- [x] **srcset候補の実寸検証**: sharpで全候補を確認し、宣言幅と実際のピクセル幅が一致・フォーマットは本物のwebp。CLAUDE.md記載の既知障害（`imageService: 'compile'` + `prerenderEnvironment: 'node'` でsrcset候補が未縮小の元画像コピーになる）の再発なし
- [x] ヒーロー画像のsrcset/sizesは変更前と同一、CaptionedImage/ImageGridの明示widths/sizesも維持
- [x] Markdown画像に `width`/`height` 属性が残っており、PhotoSwipeライトボックス（srcset最大幅候補をパース）との互換OK
- [x] `inferSize` 属性がHTML出力から消失
- [x] OGP画像16件の生成正常、`responsiveStyles` はデフォルトoffのためCSS注入なし・既存スタイルとの競合なし
- [x] `_astro/` 画像は516→534ファイル（候補増加分、約+3%）
- [x] typecheck / lint:check / format:check / test（63件）/ build すべて通過

## 備考

`CaptionedImage` / `ImageGrid` の手動widths/sizes指定の削除・簡略化は、出力変化を伴うため今回は見送り（検討するなら見た目確認込みの別PRで）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)